### PR TITLE
Change Compiler to Clang++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ QEMU = $(shell command -v qemu-system-$(QEMU_ARCH))
 # Compilers/Assemblers/Linkers
 AS      = $(shell command -v i686-elf-as)
 NASM    = $(shell command -v nasm)
-CXX     = $(shell command -v i686-elf-gcc)
+CXX     = $(shell command -v clang++)
 LD      = $(shell command -v i686-elf-ld)
 OBJCP   = $(shell command -v i686-elf-objcopy)
 MKGRUB  = $(shell command -v grub-mkrescue)
@@ -51,24 +51,28 @@ MKGRUB  = $(shell command -v grub-mkrescue)
 CFLAGS =                   \
 	-I ${SYSROOT}/usr/include/kernel/
 # C++ only flags (-lgcc flag is used b/c it has helpful functions)
+# Flags explained:
+#
+# -Wno-unused-function
+# We need to ignore unused functions because we may use
+# them at a later time. For example, paging disable.
+#
 CXXFLAGS =                  \
-	-m32                    \
 	-g                      \
-	-nostartfiles           \
-	-nodefaultlibs          \
-	-lgcc                   \
+	-m32                    \
+	-target i386-none-elf   \
 	-ffreestanding          \
 	-fstack-protector-all   \
 	-fpermissive            \
+	-nodefaultlibs          \
 	-fno-use-cxa-atexit     \
 	-fno-builtin            \
 	-fno-rtti               \
 	-fno-exceptions         \
-	-fno-leading-underscore \
 	-fno-omit-frame-pointer \
-	-Wno-write-strings      \
 	-Wall                   \
 	-Werror                 \
+	-Wno-unused-function    \
 	-std=c++17
 # C / C++ pre-processor flags
 CPP_FLAGS =                 \

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ QEMU = $(shell command -v qemu-system-$(QEMU_ARCH))
 
 # Compilers/Assemblers/Linkers
 AS      = $(shell command -v i686-elf-as)
-NASM    = $(shell command -v nasm)
+NASM    = $(shell command -v llc)
 CXX     = $(shell command -v clang++)
-LD      = $(shell command -v i686-elf-ld)
-OBJCP   = $(shell command -v i686-elf-objcopy)
+LD      = $(shell command -v ld.lld)
+OBJCP   = $(shell command -v llvm-objcopy)
 MKGRUB  = $(shell command -v grub-mkrescue)
 # C / C++ flags (include directory)
 CFLAGS =                   \

--- a/kernel/dev/rtc/rtc.cpp
+++ b/kernel/dev/rtc/rtc.cpp
@@ -17,12 +17,13 @@
 
 void px_rtc_callback(registers_t *regs);
 // Current values from RTC
-uint8_t px_rtc_second; // Current UTC second
-uint8_t px_rtc_minute; // Current UTC minute
-uint8_t px_rtc_hour;   // Current UTC hour
-uint8_t px_rtc_day;    // Current UTC day (not reliable)
-uint8_t px_rtc_month;  // Current UTC month
-uint32_t px_rtc_year;  // Current UTC year
+uint8_t px_rtc_second;      // Current UTC second
+uint8_t px_rtc_minute;      // Current UTC minute
+uint8_t px_rtc_hour;        // Current UTC hour
+uint8_t px_rtc_day;         // Current UTC day (not reliable)
+uint8_t px_rtc_month;       // Current UTC month
+uint32_t px_rtc_year;       // Current UTC year
+uint32_t px_rtc_century;    // Current UTC century
 
 void px_rtc_init() {
     px_kprintf(DBG_INFO "Initializing RTC...\n");
@@ -62,9 +63,10 @@ uint8_t px_rtc_get_register(int reg) {
 void px_read_rtc() {
     // Previous values from RTC
     // Used as a cache to check if we should update
-    uint8_t px_rtc_century, last_second, last_minute, 
-            last_hour, last_day, last_month,
-            last_year, last_century, registerB;
+    uint8_t last_second = 0, last_minute = 0,
+            last_hour = 0, last_day = 0,
+            last_month = 0, last_year = 0,
+            last_century = 0, registerB = 0;
     // Make sure an update isn't in progress
     while (px_rtc_get_update_in_progress());
 

--- a/kernel/dev/serial/rs232.cpp
+++ b/kernel/dev/serial/rs232.cpp
@@ -45,7 +45,7 @@ static void px_rs232_write_char(char c) {
     px_write_byte(rs_232_port_base + RS_232_DATA_REG, c);
 }
 
-void px_rs232_print(char* str) {
+void px_rs232_print(const char* str) {
     for (int i = 0; str[i] != 0; i++) {
         px_rs232_write_char(str[i]);
     }

--- a/kernel/lib/string.cpp
+++ b/kernel/lib/string.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <lib/string.hpp>
+#include <mem/heap.hpp>
 
 int strlen(const char* s) {
     int i = 0;
@@ -19,11 +20,11 @@ int strlen(const char* s) {
     return i;
 }
 
+//TODO: Fix this function. I don't think it works.
 char* strcat(const char *s1, const char *s2) {
     const size_t len1 = strlen(s1);
     const size_t len2 = strlen(s2);
-    char *result = "";
-    // = malloc(len1 + len2 + 1); // +1 for the null-terminator
+    char *result = (char *)malloc(len1 + len2 + 1); // +1 for the null-terminator
     // in real code you would check for errors in malloc here
     memcpy(result, s1, len1);
     memcpy(result + len1, s2, len2 + 1); // +1 to copy the null-terminator

--- a/kernel/sys/panic.cpp
+++ b/kernel/sys/panic.cpp
@@ -23,7 +23,7 @@ void panic_print_register(registers_t *regs);
 
 void printPanicScreen(int exception) {
     px_tty_clear(VGA_Black, VGA_White);
-    char* tag;
+    const char* tag;
     if (exception == 13) {
         tag = "< Wait... That's Illegal >\n";
     } else {
@@ -47,7 +47,7 @@ void printPanicScreen(int exception) {
     px_rs232_print(cow);
 }
 
-void panic(char* msg, const char *file, uint32_t line, const char *func) {
+void panic(const char* msg, const char *file, uint32_t line, const char *func) {
     asm volatile ("cli");
     // Print the panic cow
     printPanicScreen(0);

--- a/sysroot/usr/include/kernel/dev/serial/rs232.hpp
+++ b/sysroot/usr/include/kernel/dev/serial/rs232.hpp
@@ -45,7 +45,7 @@ void px_rs232_init(uint16_t com_id);
  * serial output.
  * @param str Input string to be printed.
  */
-void px_rs232_print(char* str);
+void px_rs232_print(const char* str);
 
 /**
  * @brief Initializes the serial input buffer and

--- a/sysroot/usr/include/kernel/sys/panic.hpp
+++ b/sysroot/usr/include/kernel/sys/panic.hpp
@@ -28,7 +28,7 @@ extern const char* px_exception_descriptions[];
  * @param line Line with the error
  * @param func Function containing error
  */
-void panic(char* msg, const char *file, uint32_t line, const char *func);
+void panic(const char* msg, const char *file, uint32_t line, const char *func);
 /**
  * @brief Halts kernel execution and prints register info.
  * 


### PR DESCRIPTION
Some changes were made in order to get the code to compile since Clang forces a code to conform to the ISO standard a bit more (which is fine by me).

`-Wno-unused-function` was added so that we don't have to worry about unused functions for now since we may end up using them in the future. Other incompatible flags were also removed.