### PR TITLE
Fix Global Constructors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,20 @@ export COLOR_OK   = \033[0;32m
 export COLOR_INFO = \033[0;93m
 export COLOR_NONE = \033[m
 
+# *******************
+# * i686 Toolchains *
+# *******************
+
+# Compilers/Assemblers/Linkers
+export NASM    := $(shell command -v nasm)
+export AS      := $(shell command -v i686-elf-as)
+export AR      := $(shell command -v i686-elf-ar)
+export CC      := $(shell command -v i686-elf-gcc)
+export CXX     := $(shell command -v i686-elf-g++)
+export LD      := $(shell command -v i686-elf-ld)
+export OBJCP   := $(shell command -v i686-elf-objcopy)
+export MKGRUB  := $(shell command -v grub-mkrescue)
+
 # *****************************
 # * Source Code & Directories *
 # *****************************
@@ -45,21 +59,7 @@ TESTS   = tests
 # solve it by just having GCC tell me where it is and then linking against
 # that absolute path directly. That way I never have to deal with it again
 export LIB_DIRS := $(shell find $(LIBRARY) -mindepth 1 -maxdepth 1 -type d)
-export LIB_GCC  := $(shell i686-elf-gcc -print-libgcc-file-name)
-
-# *******************
-# * i686 Toolchains *
-# *******************
-
-# Compilers/Assemblers/Linkers
-export NASM    := $(shell command -v nasm)
-export AS      := $(shell command -v i686-elf-as)
-export AR      := $(shell command -v i686-elf-ar)
-export CC      := $(shell command -v i686-elf-gcc)
-export CXX     := $(shell command -v i686-elf-g++)
-export LD      := $(shell command -v i686-elf-ld)
-export OBJCP   := $(shell command -v i686-elf-objcopy)
-export MKGRUB  := $(shell command -v grub-mkrescue)
+export LIB_GCC  := $(shell $(CC) -print-libgcc-file-name)
 
 # *******************
 # * Toolchain Flags *
@@ -201,6 +201,17 @@ run: $(PRODUCT)/$(KERNEL)
 	-kernel $(PRODUCT)/$(KERNEL) \
 	$(QEMU_FLAGS)
 
+# Open the connection to qemu and load our kernel-object file with symbols
+.PHONY: run-debug
+run-debug: $(PRODUCT)/$(KERNEL)
+	# Start QEMU with debugger
+	($(QEMU)   \
+	-S -s      \
+	-kernel $< \
+	$(QEMU_FLAGS) > /dev/null &)
+	sleep 1
+	wmctrl -xr qemu.Qemu-system-$(QEMU_ARCH) -b add,above
+
 # Create Virtualbox VM
 .PHONY: vbox-create
 vbox-create: $(PRODUCT)/$(ISOIMG)
@@ -216,17 +227,6 @@ vbox-create: $(PRODUCT)/$(ISOIMG)
 .PHONY: vbox-create
 vbox: vbox-create
 	$(VBOX) startvm --putenv --debug $(VM_NAME)
-
-# Open the connection to qemu and load our kernel-object file with symbols
-.PHONY: debugger
-debugger: $(PRODUCT)/$(KERNEL)
-	# Start QEMU with debugger
-	($(QEMU)   \
-	-S -s      \
-	-kernel $< \
-	$(QEMU_FLAGS) > /dev/null &)
-	sleep 1
-	wmctrl -xr qemu.Qemu-system-$(QEMU_ARCH) -b add,above
 
 # ****************************
 # * Documentation Generation *

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -4,7 +4,7 @@
 # |  __/ (_| | | | | |>  <  | . \  __/ |  | | | |  __/ |
 # |_|   \__,_|_| |_|_/_/\_\ |_|\_\___|_|  |_| |_|\___|_|
 #
-# Compiles the kernel source code located in the kernel folder.
+# Compiles the kernel source code.
 
 # Designed by Keeton Feavel & Micah Switzer
 # Copyright the Panix Contributors (c) 2019
@@ -56,11 +56,13 @@ LDFLAGS +=                 \
 # *************************
 
 # All objects
-OBJ_C   = $(patsubst %.c,   $(BUILD)/%.o, $(C_SRC))
-OBJ_CPP = $(patsubst %.cpp, $(BUILD)/%.o, $(CPP_SRC))
-OBJ_ASM = $(patsubst %.s,   $(BUILD)/%.o, $(ATT_SRC)) \
-          $(patsubst %.S,   $(BUILD)/%.o, $(NASM_SRC))
-OBJ     = $(OBJ_CPP) $(OBJ_C) $(OBJ_ASM)
+OBJ_C     = $(patsubst %.c,   $(BUILD)/%.o, $(C_SRC))
+OBJ_CPP   = $(patsubst %.cpp, $(BUILD)/%.o, $(CPP_SRC))
+OBJ_ASM   = $(patsubst %.s,   $(BUILD)/%.o, $(ATT_SRC)) \
+            $(patsubst %.S,   $(BUILD)/%.o, $(NASM_SRC))
+OBJ_CRTI := $(shell $(CC) -print-file-name=crtbegin.o)
+OBJ_CRTN := $(shell $(CC) -print-file-name=crtend.o)
+OBJ       = $(OBJ_CPP) $(OBJ_C) $(OBJ_ASM) $(OBJ_CRTI) $(OBJ_CRTN)
 # Object directories, mirroring source
 OBJ_DIRS = $(addprefix $(BUILD), $(shell find . -type d | sed "s|^\.||"))
 # Create object file directories

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -56,13 +56,16 @@ LDFLAGS +=                 \
 # *************************
 
 # All objects
-OBJ_C     = $(patsubst %.c,   $(BUILD)/%.o, $(C_SRC))
-OBJ_CPP   = $(patsubst %.cpp, $(BUILD)/%.o, $(CPP_SRC))
-OBJ_ASM   = $(patsubst %.s,   $(BUILD)/%.o, $(ATT_SRC)) \
-            $(patsubst %.S,   $(BUILD)/%.o, $(NASM_SRC))
-OBJ_CRTI := $(shell $(CC) -print-file-name=crtbegin.o)
-OBJ_CRTN := $(shell $(CC) -print-file-name=crtend.o)
-OBJ       = $(OBJ_CPP) $(OBJ_C) $(OBJ_ASM) $(OBJ_CRTI) $(OBJ_CRTN)
+OBJ_CRTBEGIN := $(shell $(CC) -print-file-name=crtbegin.o)
+OBJ_CRTEND   := $(shell $(CC) -print-file-name=crtend.o)
+OBJ_CRTI     := $(BUILD)/arch/i386/crti.o # hard-coded for now
+OBJ_CRTN     := $(BUILD)/arch/i386/crtn.o # hard-coded for now
+OBJ_C        := $(patsubst %.c,   $(BUILD)/%.o, $(C_SRC))
+OBJ_CPP      := $(patsubst %.cpp, $(BUILD)/%.o, $(CPP_SRC))
+OBJ_ASM_ALL  := $(patsubst %.s,   $(BUILD)/%.o, $(ATT_SRC)) \
+                $(patsubst %.S,   $(BUILD)/%.o, $(NASM_SRC))
+OBJ_ASM      := $(filter-out $(OBJ_CRTI) $(OBJ_CRTN),$(OBJ_ASM_ALL))
+OBJ          := $(OBJ_CRTI) $(OBJ_CRTBEGIN) $(OBJ_CPP) $(OBJ_C) $(OBJ_ASM) $(OBJ_CRTEND) $(OBJ_CRTN)
 # Object directories, mirroring source
 OBJ_DIRS = $(addprefix $(BUILD), $(shell find . -type d | sed "s|^\.||"))
 # Create object file directories

--- a/kernel/arch/i386/boot.s
+++ b/kernel/arch/i386/boot.s
@@ -1,11 +1,14 @@
 # make the _start function available to the linker
 .global _start
 
+# global constructor and destructor calls
+.extern _init
+.extern _fini
+
 # external reference to our global constructors and kernel main functions
 # which are defined in our main.cpp file. This allows assembly to call
 # function in C++ by telling the compiler they exist "somewhere"
 .extern px_kernel_main
-.extern px_call_constructors
 # minimal panic function that works in most situations
 .extern early_panic
 
@@ -159,8 +162,12 @@ _start.has_sse:
     # Set NULL stack frame for trace
     xor %ebp, %ebp
 
+    # Call global constructors
+    call _init
     # Enter the high-level kernel.
     call px_kernel_main
+    # Call global destructors
+    call _fini
 
     # By this point we should be into the wild world of C++
     # So, this should never be called unless the kernel returns

--- a/kernel/arch/i386/crti.s
+++ b/kernel/arch/i386/crti.s
@@ -1,0 +1,16 @@
+/* x86 crti.s */
+.section .init
+.global _init
+.type _init, @function
+_init:
+	push %ebp
+	movl %esp, %ebp
+	/* gcc will nicely put the contents of crtbegin.o's .init section here. */
+
+.section .fini
+.global _fini
+.type _fini, @function
+_fini:
+	push %ebp
+	movl %esp, %ebp
+	/* gcc will nicely put the contents of crtbegin.o's .fini section here. */

--- a/kernel/arch/i386/crtn.s
+++ b/kernel/arch/i386/crtn.s
@@ -1,0 +1,10 @@
+/* x86 crtn.s */
+.section .init
+	/* gcc will nicely put the contents of crtend.o's .init section here. */
+	popl %ebp
+	ret
+
+.section .fini
+	/* gcc will nicely put the contents of crtend.o's .fini section here. */
+	popl %ebp
+	ret

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -36,38 +36,10 @@
 #define VERSION "unknown"
 #endif
 
-extern "C" void px_call_constructors();
 extern "C" void __stack_chk_fail(void);
 extern "C" void px_kernel_main(const multiboot_info_t* mb_struct, uint32_t mb_magic);
 void px_kernel_print_splash();
 void px_kernel_boot_tone();
-
-/**
- * @brief The global constuctor is a necessary step when using
- * global objects which need to be constructed before the main
- * function, px_kernel_main() in our case, is ever called. This
- * is much more necessary in an object-oriented architecture,
- * so it is less of a concern now. Regardless, the OSDev Wiki
- * take a *very* different approach to this, so refactoring
- * this might be on the eventual todo list.
- *
- * According to the OSDev Wiki this is only necessary for C++
- * objects. However, it is useful to know that the
- * global constructors are "stored in a sorted array of
- * function pointers and invoking these is as simple as
- * traversing the array and running each element."
- *
- */
-typedef void (*constructor)();
-extern "C" constructor _CTORS_START;
-extern "C" constructor _CTORS_END;
-extern "C" void px_call_constructors() {
-    // For each global object with a constructor starting at start_ctors,
-    for (constructor* i = &_CTORS_START; i != &_CTORS_END; i++) {
-        // Get the object and call the constructor manually.
-        (*i)();
-    }
-}
 
 /**
  * @brief This function is the global handler for all


### PR DESCRIPTION
Closes #168 

Adds support for C++ global constructors using the "official" method described in the OSDev Wiki (i.e. this way actually follows the C++ ABI).