### PR TITLE
Add Defines for ELF Sections

### DIFF
--- a/kernel/arch/i386/boot/boot.s
+++ b/kernel/arch/i386/boot/boot.s
@@ -12,6 +12,7 @@
 # minimal panic function that works in most situations
 .extern early_panic
 
+.extern _KERNEL_BASE
 .extern _KERNEL_START
 .extern _KERNEL_END
 .extern _BSS_START
@@ -22,7 +23,6 @@
 .extern _EARLY_BSS_START
 .extern _EARLY_BSS_SIZE
 
-.equ KERNEL_BASE, 0xC0000000
 .equ LOWMEM_END, _EARLY_KERNEL_END        # lowmem ends at the 1st MB
 .equ PAGE_SIZE, 4096
 .equ PAGE_SHIFT, 12                 # 2^12 = 4096 = PAGE_SIZE
@@ -94,7 +94,7 @@ _start.higher:
     andl $0x3ff, %ecx # generate kernel PTE index
 
     movl %eax, %ebx
-    subl $KERNEL_BASE, %ebx # convert virt->physical
+    subl $_KERNEL_BASE, %ebx # convert virt->physical
     movl %ebx, kernel_pt(%edx,%ecx,4)
     orl $PAGE_PERM, kernel_pt(%edx,%ecx,4)
 

--- a/kernel/arch/i386/linker.ld
+++ b/kernel/arch/i386/linker.ld
@@ -1,5 +1,13 @@
-/* Tell our linker that our entry point is the boot_loader function
- * which we defined in the boot.s file.
+/**
+ * @file linker.ld
+ * @author Micah Switzer (mswitzer@cedarville.edu)
+ *         Keeton Feavel (keetonfeavel@cedarville.edu)
+ * @brief i386 kernel linker script
+ * @version 0.1
+ * @date 2021-06-27
+ *
+ * @copyright Copyright the Panix Contributors (c) 2021
+ *
  */
 ENTRY(_start)
 OUTPUT_FORMAT(elf32-i386)
@@ -25,13 +33,14 @@ SECTIONS
     _EARLY_KERNEL_END = .;
 
     /* Higher half kernel, linked at 3GB */
+    _KERNEL_BASE = 0xC0000000;
     . += 0xC0000000;
 
     _KERNEL_START = .;
 
-    .text ALIGN (4K) : AT(ADDR(.text) - 0xC0000000) { *(.text) }
-    .rodata ALIGN (4K) : AT(ADDR(.rodata) - 0xC0000000) { *(.rodata*) }
-    .data ALIGN (4K) : AT(ADDR(.data) - 0xC0000000)
+    .text ALIGN (4K) : AT(ADDR(.text) - _KERNEL_BASE) { *(.text) }
+    .rodata ALIGN (4K) : AT(ADDR(.rodata) - _KERNEL_BASE) { *(.rodata*) }
+    .data ALIGN (4K) : AT(ADDR(.data) - _KERNEL_BASE)
     {
         _CTORS_START = .;
         KEEP(*(.init_array));
@@ -39,14 +48,14 @@ SECTIONS
         _CTORS_END = .;
         *(.data)
     }
-    .bss ALIGN (4K) : AT(ADDR(.bss) - 0xC0000000)
+    .bss ALIGN (4K) : AT(ADDR(.bss) - _KERNEL_BASE)
     {
         _BSS_START = .;
         *(.bss)
         *(COMMON)
         _BSS_END = .;
     }
-    .page_tables ALIGN (4K) : AT(ADDR(.page_tables) - 0xC0000000)
+    .page_tables ALIGN (4K) : AT(ADDR(.page_tables) - _KERNEL_BASE)
     {
         *(.page_tables)
     }

--- a/sysroot/usr/include/kernel/mem/paging.hpp
+++ b/sysroot/usr/include/kernel/mem/paging.hpp
@@ -14,19 +14,14 @@
 #include <stddef.h>
 #include <arch/arch.hpp>
 #include <mem/heap.hpp>
+#include <meta/sections.hpp>
 
-// Information about the Kernel from the linker
-extern uint32_t _KERNEL_START;
-extern uint32_t _KERNEL_END;
 extern "C" void invalidate_page(void *page_addr);
 
 // Thanks to Grant Hernandez for uOS and the absolutely amazing code
 // that he wrote. It helped us fix a lot of bugs and has provided a
 // lot of quality of life defines such as the ones below that we would
 // not have thought to use otherwise.
-#define KERNEL_START        ((uint32_t)&_KERNEL_START)
-#define KERNEL_END          ((uint32_t)&_KERNEL_END)
-#define KERNEL_BASE         0xC0000000
 #define ADDRESS_SPACE_SIZE  0x100000000
 #define PAGE_SIZE           0x1000
 #define PAGE_ALIGN          0xfffff000

--- a/sysroot/usr/include/kernel/meta/sections.hpp
+++ b/sysroot/usr/include/kernel/meta/sections.hpp
@@ -1,0 +1,49 @@
+/**
+ * @file kernel.hpp
+ * @author Keeton Feavel (keetonfeavel@cedarville.edu)
+ * @brief Kernel ELF section definitions
+ * @version 0.1
+ * @date 2021-06-27
+ * 
+ * @copyright Copyright the Panix Contributors (c) 2021
+ * 
+ */
+#pragma once
+
+#include <stddef.h>
+
+// Kernel ELF Sections
+// Externs (address values) are prefixed with an underscore
+// Pointers to sections have the underscore removed
+extern size_t _EARLY_KERNEL_START;
+#define EARLY_KERNEL_START ((uintptr_t)&_EARLY_KERNEL_START)
+extern size_t _EARLY_KERNEL_END;
+#define EARLY_KERNEL_END ((uintptr_t)&_EARLY_KERNEL_END)
+
+extern size_t _KERNEL_BASE;
+#define KERNEL_BASE ((uintptr_t)&_KERNEL_BASE)
+
+extern size_t _KERNEL_START;
+#define KERNEL_START ((uintptr_t)&_KERNEL_START)
+extern size_t _KERNEL_END;
+#define KERNEL_END ((uintptr_t)&_KERNEL_END)
+
+extern size_t _EARLY_BSS_START;
+#define EARLY_BSS_START ((uintptr_t)&_EARLY_BSS_START)
+extern size_t _EARLY_BSS_END;
+#define EARLY_BSS_END ((uintptr_t)&_EARLY_BSS_END)
+
+extern size_t _CTORS_START;
+#define CTORS_START ((uintptr_t)&_CTORS_START)
+extern size_t _CTORS_END;
+#define CTORS_END ((uintptr_t)&_CTORS_END)
+
+extern size_t _BSS_START;
+#define BSS_START ((uintptr_t)&_BSS_START)
+extern size_t _BSS_END;
+#define BSS_END ((uintptr_t)&_BSS_END)
+
+extern size_t _PAGE_TABLES_START;
+#define PAGE_TABLES_START ((uintptr_t)&_PAGE_TABLES_START)
+extern size_t _PAGE_TABLES_END;
+#define PAGE_TABLES_END ((uintptr_t)&_PAGE_TABLES_END)


### PR DESCRIPTION
Standardizes the way the kernel base and some sections are accessed. Should help with converting parts of `boot.s` to C when we start on that.