### PR TITLE
Refactor Makefile to Share Common Variables & Fix Unit Tests

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -23,7 +23,7 @@ jobs:
     - name: 'Build Kernel (Debug)'
       run: make debug
     - name: 'Build Image (Debug)'
-      run: make dist/panix.img
+      run: make dist
     - name: 'Upload Artifact'
       uses: actions/upload-artifact@v2
       with:
@@ -37,7 +37,7 @@ jobs:
     - name: 'Build Kernel (Release)'
       run: make release
     - name: 'Build Image (Release)'
-      run: make dist/panix.img
+      run: make dist
     - name: 'Upload Artifact'
       uses: actions/upload-artifact@v2
       with:

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -14,13 +14,7 @@
 # *****************************
 
 # Directories & files
-BUILD   = ../obj
-KERNEL  = kernel
-SYMBOLS = $(KERNEL).sym
-PRODUCT = ../dist
-LIBRARY = ../libs
-SYSROOT	= ../sysroot
-INCLUDE = $(SYSROOT)/usr/include
+INCLUDE  = $(SYSROOT_DIR)/usr/include
 
 # The `| sed "s|^\./||"` command is included to remove the leading
 # ./ from all of the paths so that the objects are generated
@@ -37,20 +31,29 @@ C_HDR    = $(shell find $(INCLUDE) -type f -name "*.h" | sed "s|^\./||")
 CPP_HDR  = $(shell find $(INCLUDE) -type f -name "*.hpp" | sed "s|^\./||")
 HEADERS  = $(CPP_HDR) $(C_HDR)
 #Libraries
-LIBS_A   = $(shell find $(LIBRARY) -type f -name "*.a")
+LIBS_A   = $(shell find $(LIBRARY_DIR) -type f -name "*.a" -printf "%f\n")
 LIBS     = $(addprefix -l:, $(LIBS_A))
 
 # *******************
 # * Toolchain Flags *
 # *******************
 
-CPPFLAGS +=               \
-	-I ${INCLUDE}/kernel/ \
-	-I ${INCLUDE}/boot/   \
-	-I ../thirdparty/
+CPPFLAGS +=                \
+	-I ${INCLUDE}/kernel/  \
+	-I ${INCLUDE}/boot/    \
+	-I $(THIRDPARTY_DIR)
+
+# Add compiler analysis to the kernel compilation
+# Added here instead of in the root-level makefile
+# since this option isn't recognized by Clang, which
+# may be the host's compiler, thus making unit tests
+# not compiler properly.
+CXXFLAGS +=                \
+	-fanalyzer             \
 
 LDFLAGS +=                 \
 	-T arch/i386/linker.ld \
+	-L $(LIBRARY_DIR)/**   \
 	$(LIBS)                \
 
 # *************************
@@ -60,16 +63,16 @@ LDFLAGS +=                 \
 # All objects
 OBJ_CRTBEGIN := $(shell $(CC) -print-file-name=crtbegin.o)
 OBJ_CRTEND   := $(shell $(CC) -print-file-name=crtend.o)
-OBJ_CRTI     := $(BUILD)/arch/i386/crti.o # hard-coded for now
-OBJ_CRTN     := $(BUILD)/arch/i386/crtn.o # hard-coded for now
-OBJ_C        := $(patsubst %.c,   $(BUILD)/%.o, $(C_SRC))
-OBJ_CPP      := $(patsubst %.cpp, $(BUILD)/%.o, $(CPP_SRC))
-OBJ_ASM_ALL  := $(patsubst %.s,   $(BUILD)/%.o, $(ATT_SRC)) \
-                $(patsubst %.S,   $(BUILD)/%.o, $(NASM_SRC))
+OBJ_CRTI     := $(BUILD_DIR)/arch/i386/crti.o # hard-coded for now
+OBJ_CRTN     := $(BUILD_DIR)/arch/i386/crtn.o # hard-coded for now
+OBJ_C        := $(patsubst %.c,   $(BUILD_DIR)/%.o, $(C_SRC))
+OBJ_CPP      := $(patsubst %.cpp, $(BUILD_DIR)/%.o, $(CPP_SRC))
+OBJ_ASM_ALL  := $(patsubst %.s,   $(BUILD_DIR)/%.o, $(ATT_SRC)) \
+                $(patsubst %.S,   $(BUILD_DIR)/%.o, $(NASM_SRC))
 OBJ_ASM      := $(filter-out $(OBJ_CRTI) $(OBJ_CRTN),$(OBJ_ASM_ALL))
 OBJ          := $(OBJ_CRTI) $(OBJ_CRTBEGIN) $(OBJ_CPP) $(OBJ_C) $(OBJ_ASM) $(OBJ_CRTEND) $(OBJ_CRTN)
 # Object directories, mirroring source
-OBJ_DIRS = $(addprefix $(BUILD), $(shell find . -type d | sed "s|^\.||"))
+OBJ_DIRS = $(addprefix $(BUILD_DIR), $(shell find . -type d | sed "s|^\.||"))
 # Create object file directories
 OBJ_DIRS_MAKE := mkdir -p $(OBJ_DIRS)
 # Dependency files
@@ -80,30 +83,30 @@ ALLFILES = $(ATT_SRC) $(NASM_SRC) $(C_SRC) $(CPP_SRC) $(HEADERS)
 -include $(DEP)
 
 # C source -> object
-$(BUILD)/%.o: %.c $(HEADERS)
+$(BUILD_DIR)/%.o: %.c $(HEADERS)
 	@$(OBJ_DIRS_MAKE)
-	@printf "$(COLOR_COM)(CC)$(COLOR_NONE)\t$@\n"
+	@printf "$(COLOR_COM)(CC)$(COLOR_NONE)\t$(shell basename $@)\n"
 	@$(CC) $(CPPFLAGS) $(CFLAGS) $(CWARNINGS) -std=c17 -MMD -c -o $@ $<
 # C++ source -> object
-$(BUILD)/%.o: %.cpp $(HEADERS)
+$(BUILD_DIR)/%.o: %.cpp $(HEADERS)
 	@$(OBJ_DIRS_MAKE)
-	@printf "$(COLOR_COM)(CXX)$(COLOR_NONE)\t$@\n"
-	@$(CXX) $(CPPFLAGS) $(CFLAGS) $(CXXFLAGS) -MMD -c -o $@ $<
+	@printf "$(COLOR_COM)(CXX)$(COLOR_NONE)\t$(shell basename $@)\n"
+	@$(CXX) $(CPPFLAGS) $(CFLAGS) $(CXXFLAGS) -std=c++17 -MMD -c -o $@ $<
 # GAS assembly -> object
-$(BUILD)/%.o: %.s
+$(BUILD_DIR)/%.o: %.s
 	@$(OBJ_DIRS_MAKE)
-	@printf "$(COLOR_COM)(AS)$(COLOR_NONE)\t$@\n"
+	@printf "$(COLOR_COM)(AS)$(COLOR_NONE)\t$(shell basename $@)\n"
 	@$(AS) $(ASFLAGS) -o $@ $<
 # NASM assembly -> object
-$(BUILD)/%.o: %.S
+$(BUILD_DIR)/%.o: %.S
 	@$(OBJ_DIRS_MAKE)
-	@printf "$(COLOR_COM)(NASM)$(COLOR_NONE)\t$@\n"
+	@printf "$(COLOR_COM)(NASM)$(COLOR_NONE)\t$(shell basename $@)\n"
 	@$(NASM) -f elf32 -o $@ $<
 # Kernel object
-$(KERNEL): $(PRODUCT)/$(KERNEL)
-$(PRODUCT)/$(KERNEL): $(OBJ)
-	@mkdir -p $(PRODUCT)
-	@printf "$(COLOR_COM)(LD)$(COLOR_NONE)\t$@\n"
+$(KERNEL): $(PRODUCTS_DIR)/$(KERNEL)
+$(PRODUCTS_DIR)/$(KERNEL): $(OBJ)
+	@mkdir -p $(PRODUCTS_DIR)
+	@printf "$(COLOR_COM)(LD)$(COLOR_NONE)\t$(shell basename $@)\n"
 	@$(CXX) -o $@ $(OBJ) $(LDFLAGS)
-	@printf "$(COLOR_COM)(OBJCP)$(COLOR_NONE)\t$@\n"
-	@$(OBJCP) --only-keep-debug $(PRODUCT)/$(KERNEL) $(PRODUCT)/$(SYMBOLS)
+	@printf "$(COLOR_COM)(OBJCP)$(COLOR_NONE)\t$(shell basename $@)\n"
+	@$(OBJCP) --only-keep-debug $(PRODUCTS_DIR)/$(KERNEL) $(PRODUCTS_DIR)/$(SYMBOLS)

--- a/kernel/lib/bitmap.cpp
+++ b/kernel/lib/bitmap.cpp
@@ -15,8 +15,8 @@ size_t bitmap_find_first_range_clear(bitmap_t *bitmap, size_t size, size_t count
         check = check_lo | check_hi;
 #ifdef TESTING
         size_t masked = check & mask;
-        printf("i = %d, idx = 0x%08x, ofst = 0x%08x, check_lo = 0x%08x, "
-               "check_hi = 0x%08x, check = 0x%08x, masked = 0x%08x\n",
+        printf("i = %zd, idx = 0x%08zx, ofst = 0x%08zx, check_lo = 0x%08zx, "
+               "check_hi = 0x%08zx, check = 0x%08zx, masked = 0x%08zx\n",
                 i, idx, ofst, check_lo, check_hi, check, masked);
 #endif
         if (!(check & mask)) return i;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,37 +14,71 @@
 # *****************************
 
 # Directories & files
-KERNEL  = kernel
-SYSROOT	= ../sysroot
-INCLUDE = $(SYSROOT)/usr/include
+OUTPUT      := unit-test
+INCLUDE     := $(SYSROOT_DIR)/usr/include
+KERNEL_SRC  := $(ROOT)/$(KERNEL)
 
-# Define the compilation flags for the tests.
-CXXFLAGS +=            \
-	-Wno-write-strings
-
-CPPFLAGS +=                 \
-	-I$(INCLUDE)/$(KERNEL)/ \
-	-DTESTING
 # Use the host's copy of GCC instead of the i686 cross compiler
 # since it does not have a standard library (if compiled properly)
-CXX 	:= $(shell command -v gcc)
-# macOS does not support compiling for i386
-# so we only add the -m32 flag for Linux hosts.
-UNAME_S := $(shell uname -s)
+CXX := $(shell command -v gcc)
 
-run_tests: *.cpp
-ifeq ($(UNAME_S), Linux)
-	CXXFLAGS += -m32
-endif
-ifeq ($(UNAME_S), Darwin)
-	@printf "\n$(COLOR_INFO)WARNING$(COLOR_NONE): Compiling for Darwin (amd64)\n\n"
-endif
-	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $< ../$(KERNEL)/lib/bitmap.cpp
+# C / C++
+C_SRC    = $(shell find . -type f -name "*.c" | sed "s|^\./||")
+CPP_SRC  = $(shell find . -type f -name "*.cpp" | sed "s|^\./||")
+# Headers
+C_HDR    = $(shell find $(INCLUDE) -type f -name "*.h" | sed "s|^\./||")
+CPP_HDR  = $(shell find $(INCLUDE) -type f -name "*.hpp" | sed "s|^\./||")
+HEADERS  = $(CPP_HDR) $(C_HDR)
 
-.PHONY: test
-test: run_tests
-	@./run_tests
+# *******************
+# * Toolchain Flags *
+# *******************
 
-.PHONY: clean
-clean:
-	@$(RM) run_tests
+CXXFLAGS =                   \
+	-Wno-write-strings
+
+LDFLAGS =                    \
+	-lgcc
+
+CPPFLAGS +=                  \
+	-I$(KERNEL_SRC)          \
+	-I$(INCLUDE)/kernel/     \
+	-DTESTING
+
+# *************************
+# * Kernel Source Objects *
+# *************************
+
+# All objects
+OBJ_C        := $(patsubst %.c,   $(BUILD_DIR)/%.o, $(C_SRC))
+OBJ_CPP      := $(patsubst %.cpp, $(BUILD_DIR)/%.o, $(CPP_SRC))
+OBJ          := $(OBJ_CPP) $(OBJ_C)
+# Object directories, mirroring source
+OBJ_DIRS = $(addprefix $(BUILD_DIR), $(shell find . -type d | sed "s|^\.||"))
+# Create object file directories
+OBJ_DIRS_MAKE := mkdir -p $(OBJ_DIRS)
+# Dependency files
+DEP = $(OBJ_CPP:%.o=%.d) $(OBJ_C:%.o=%.d)
+# All files (source, header, etc.)
+ALLFILES = $(C_SRC) $(CPP_SRC) $(HEADERS)
+# Include all .d files
+-include $(DEP)
+
+# C source -> object
+$(BUILD_DIR)/%.o: %.c $(HEADERS)
+	@$(OBJ_DIRS_MAKE)
+	@printf "$(COLOR_COM)(CC)$(COLOR_NONE)\t$(shell basename $@)\n"
+	@$(CC) $(CPPFLAGS) $(WARNINGS) $(CWARNINGS) -std=c17 -MMD -c -o $@ $<
+# C++ source -> object
+$(BUILD_DIR)/%.o: %.cpp $(HEADERS)
+	@$(OBJ_DIRS_MAKE)
+	@printf "$(COLOR_COM)(CXX)$(COLOR_NONE)\t$(shell basename $@)\n"
+	@$(CXX) $(CPPFLAGS) $(WARNINGS) $(CXXFLAGS) -std=c++17 -MMD -c -o $@ $<
+# Compile tests and run
+$(OUTPUT): $(PRODUCTS_DIR)/$(OUTPUT)
+$(PRODUCTS_DIR)/$(OUTPUT): $(OBJ)
+	@mkdir -p $(PRODUCTS_DIR)
+	@printf "$(COLOR_COM)(LD)$(COLOR_NONE)\t$(shell basename $@)\n"
+	@$(CXX) -o $@ $(OBJ) $(LDFLAGS)
+	@printf "$(COLOR_COM)(OBJCP)$(COLOR_NONE)\t$(shell basename $@)\n"
+	@$(PRODUCTS_DIR)/$(OUTPUT)

--- a/tests/test-bitmap/bitmap_tests.cpp
+++ b/tests/test-bitmap/bitmap_tests.cpp
@@ -1,7 +1,7 @@
 #include <cstdio>
-#include <lib/bitmap.hpp>
+#include <lib/bitmap.cpp>
 
-#define TEST_BITMAP_BITS 128
+#define TEST_BITMAP_BITS 192
 #define NEW_BITMAP(NAME, SIZE) bitmap_t NAME[BITMAP_SIZE((SIZE))] = { 0 }
 
 typedef bool(*test_func)(void) ;
@@ -36,7 +36,7 @@ static inline bool assert_eq_b(size_t value, size_t expected)
 static inline bool assert_eq(size_t value, size_t expected)
 {
     if (value == expected) return true;
-    printf("expected %u, got %u...", expected, value);
+    printf("expected %zu, got %zu...", expected, value);
     return false;
 }
 
@@ -105,11 +105,10 @@ int main()
         TEST(test_bitmap_find_first_bit),
         TEST(test_bitmap_find_first_range)
     };
-    int idx, passed = 0, failed = 0;
+    size_t idx, passed = 0, failed = 0;
 
     printf("beginning bitmap tests...\n");
-
-    printf("BYTE_SIZE = %u\nSIZE_T_MAX_VALUE = %u\nBITS_PER_BITMAP_T = %u\n",
+    printf("BYTE_SIZE = %u\nSIZE_T_MAX_VALUE = %zu\nBITS_PER_BITMAP_T = %zu\n",
                 BYTE_SIZE, SIZE_T_MAX_VALUE, BITS_PER_BITMAP_T);
 
     for (idx = 0; idx < sizeof(tests) / sizeof(test_t); idx++) {
@@ -124,8 +123,8 @@ int main()
         }
     }
 
-    printf("%d tests ran, %d passed, %d failed\n", idx, passed, failed);
-
+    printf("%zu tests ran, %zu passed, %zu failed\n", idx, passed, failed);
     printf("finished bitmap tests\n");
+    return 0;
 }
 


### PR DESCRIPTION
This refactor cleans up a lot of duplicated variables and make the makefile structure far more robust. I'm actually a really big fan of how this all fits together.