### PR TITLE
Force several Bitset functions to always be inlined

### DIFF
--- a/kernel/lib/bitset.cpp
+++ b/kernel/lib/bitset.cpp
@@ -12,41 +12,6 @@ Bitset::Bitset(void* buf, size_t size)
     }
 }
 
-inline size_t Bitset::Size()
-{
-    return mapSize;
-}
-
-inline size_t Bitset::TypeSize()
-{
-    return sizeof(bitmap_t) * CHAR_BIT;
-}
-
-inline size_t Bitset::Index(size_t bit)
-{
-    return bit / TypeSize();
-}
-
-inline size_t Bitset::Offset(size_t bit)
-{
-    return bit % TypeSize();
-}
-
-void Bitset::Set(size_t addr)
-{
-    map[Index(addr)] |= 1UL << Offset(addr);
-}
-
-bool Bitset::Get(size_t addr)
-{
-    return map[Index(addr)] >> Offset(addr) & 1;
-}
-
-void Bitset::Clear(size_t addr)
-{
-    map[Index(addr)] |= ~(1UL << Offset(addr));
-}
-
 size_t Bitset::FindFirstBitClear()
 {
     for (size_t i = 0; i < mapSize; i++) {

--- a/sysroot/usr/include/kernel/lib/bitset.hpp
+++ b/sysroot/usr/include/kernel/lib/bitset.hpp
@@ -13,22 +13,24 @@
 
 #include <stddef.h>
 #include <limits.h>
+#include <meta/compiler.hpp>
 
 class Bitset {
 public:
+    typedef size_t bitmap_t;
+    static ALWAYS_INLINE size_t TypeSize() { return sizeof(bitmap_t) * CHAR_BIT; }
+    
     Bitset(void* buf, size_t size);
-    void Set(size_t addr);
-    bool Get(size_t addr);
-    void Clear(size_t addr);
+    ALWAYS_INLINE size_t Size() { return mapSize; }
+    ALWAYS_INLINE void Set(size_t addr) { map[Index(addr)] |= 1UL << Offset(addr); }
+    ALWAYS_INLINE bool Get(size_t addr) { return map[Index(addr)] >> Offset(addr) & 1; }
+    ALWAYS_INLINE void Clear(size_t addr) { map[Index(addr)] &= ~(1UL << Offset(addr)); }
     size_t FindFirstBitClear();
     size_t FindFirstRangeClear(size_t count);
 
 private:
-    typedef size_t bitmap_t;
     bitmap_t* map;
     size_t mapSize;
-    inline size_t Size();
-    inline size_t TypeSize();
-    inline size_t Index(size_t bit);
-    inline size_t Offset(size_t bit);
+    ALWAYS_INLINE size_t Index(size_t bit) { return bit / TypeSize(); }
+    ALWAYS_INLINE size_t Offset(size_t bit) { return bit % TypeSize(); }
 };

--- a/sysroot/usr/include/kernel/meta/compiler.hpp
+++ b/sysroot/usr/include/kernel/meta/compiler.hpp
@@ -12,6 +12,7 @@
 
 // Function attributes
 #define NORET __attribute__((noreturn))
+#define ALWAYS_INLINE __attribute__((always_inline))
 
 // Branch prediction
 #define likely(x)   __builtin_expect(!!(x), 1)


### PR DESCRIPTION
This gives us a major performance boost. (also fixed a bug in `Bitset::Clear()`)