### PR TITLE
Update Kernel Preamble to Reflect Updated Language

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,9 @@ export PROJ_NAME = panix
 
 # Makefile flags
 # prevent make from showing "entering/leaving directory" messages
-export MAKEFLAGS   += --no-print-directory
+export MAKEFLAGS  += --no-print-directory
+# Panix Repo
+export REPO_URL   := "https://git.io/JWjEx"
 # Panix Version
 export GIT_COMMIT := "$(shell git describe --abbrev=8 --dirty --always --tags)"
 export VER_MAJOR  := "0"
@@ -120,6 +122,7 @@ export CXXFLAGS :=          \
 # C / C++ pre-processor flags
 export CPPFLAGS :=                \
 	${PANIX_CPPFLAGS}             \
+	-D REPO_URL=\"$(REPO_URL)\"   \
 	-D COMMIT=\"$(GIT_COMMIT)\"   \
 	-D VER_MAJOR=\"$(VER_MAJOR)\" \
 	-D VER_MINOR=\"$(VER_MINOR)\" \

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -10,7 +10,6 @@
  */
 // System library functions
 #include <stdint.h>
-#include <sys/kernel.hpp>
 #include <sys/panic.hpp>
 #include <sys/tasks.hpp>
 #include <lib/string.hpp>
@@ -35,6 +34,8 @@
 #include <apps/spinner.hpp>
 // Debug
 #include <lib/assert.hpp>
+// Meta
+#include <meta/defines.hpp>
 
 static Boot::Handoff handoff;
 
@@ -104,16 +105,19 @@ void kernel_main(void *boot_info, uint32_t magic) {
 static void kernel_print_splash() {
     tty_clear();
     kprintf(
-        "\033[93mWelcome to Panix %s\n"
-        "Developed by graduates and undergraduates of Cedarville University.\n"
-        "Copyright the Panix Contributors (c) %i. All rights reserved.\n\033[0m",
+        "\033[93m"
+        "Panix %s\n"
+        "Copyright the Panix Contributors (c) %i. All rights reserved.\n"
+        "Kernel source available at %s.\n"
+        "\033[0m",
         VER_NAME,
         (
             ((__DATE__)[7] - '0') * 1000 + \
             ((__DATE__)[8] - '0') * 100  + \
             ((__DATE__)[9] - '0') * 10   + \
             ((__DATE__)[10] - '0') * 1     \
-        )
+        ),
+        REPO_URL
     );
     kprintf("Commit %s (v%s.%s.%s) built on %s at %s.\n\n", COMMIT, VER_MAJOR, VER_MINOR, VER_PATCH, __DATE__, __TIME__);
 }

--- a/kernel/meta/defines.hpp
+++ b/kernel/meta/defines.hpp
@@ -1,9 +1,9 @@
 /**
- * @file kernel.hpp
+ * @file defines.hpp
  * @author Keeton Feavel (keetonfeavel@cedarville.edu)
- * @brief Global kernel definitions
+ * @brief Compiler pre-processor definitions
  * @version 0.1
- * @date 2021-02-21
+ * @date 2021-07-20
  *
  * @copyright Copyright the Panix Contributors (c) 2021
  *
@@ -22,5 +22,8 @@
 #endif
 // Panix release name
 #ifndef VER_NAME
-    #define VER_NAME "Unknown"
+    #define VER_NAME "unknown"
+#endif
+#ifndef REPO_URL
+    #define REPO_URL "(unknown)"
 #endif


### PR DESCRIPTION
Removed the "developed by graduates of Cedarville University" in order to reflect the updated repo language.