### PR TITLE
Move Kernel Build Output to `obj/kernel`

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -9,6 +9,8 @@
 # Designed by Keeton Feavel & Micah Switzer
 # Copyright the Panix Contributors (c) 2019
 
+BUILD_DIR := $(BUILD_DIR)/kernel
+
 # *****************************
 # * Source Code & Directories *
 # *****************************


### PR DESCRIPTION
Helps keep the unit test build output and the kernel output separate. Meant to do this a while back when we were refactoring the makefile, but I apparently missed it.