### PR TITLE
#280 Hot-patch (Additional Fixes)

### DIFF
--- a/gdb.commands
+++ b/gdb.commands
@@ -1,5 +1,5 @@
 target remote localhost:1234
-file dist/kernel
+file dist/debug/kernel
 break kernel_main
 set disassembly-flavor intel
 layout asm


### PR DESCRIPTION
Unfortunately there were even more issues I had missed. Apparently certain sequences of commands don't like to play nice. Adding the `MODE` variable introduced a ton of hidden issues... now I see why people use SCons.

This simplifies the `run` target to no longer depend upon a boot image (file must still exist, but it isn't managed by Make). This should eventually be reverted once I figure out how to get X11 forwarding working so that Qemu can be run through Scuba, but that's being problematic on Linux, and the Scuba MR for Docker arguments in the `.scuba.yml` file is still in review.

This also fixes the `gdb.commands` file.