### PR TITLE
Fix Bootloader Handoff Memory Conflict - #278

### DIFF
--- a/kernel/arch/i386/boot/boot.S
+++ b/kernel/arch/i386/boot/boot.S
@@ -76,28 +76,28 @@ _start.lowmem:
     mov edx, _KERNEL_START
     shr edx, 22       ; find which directory entry we need to use
 
-        ; the first page table
+    ; the first page table
     mov eax, kernel_pt
     mov [edx * 4 + page_directory], eax
     or dword [edx * 4 + page_directory], PAGE_PERM
 
-        ; the second page table
-        inc edx
-        mov eax, pages_pt
-        mov [edx * 4 + page_directory], eax
-        or dword [edx * 4 + page_directory], PAGE_PERM
+    ; the second page table
+    inc edx
+    mov eax, pages_pt
+    mov [edx * 4 + page_directory], eax
+    or dword [edx * 4 + page_directory], PAGE_PERM
 
     mov eax, _KERNEL_START ; the kernel's current virtual start
 
 _start.higher:
-        ; compute the page table offset
-        ; this only works because the two page tables are adjacent
+    ; compute the page table offset
+    ; this only works because the two page tables are adjacent
     mov edx, eax
-        shr edx, 22
-        sub edx, 0x300
-        imul edx, PAGE_SIZE
+    shr edx, 22
+    sub edx, 0x300
+    imul edx, PAGE_SIZE
 
-        mov ecx, eax
+    mov ecx, eax
     shr ecx, PAGE_SHIFT
     and ecx, 0x3ff ; generate kernel PTE index
 
@@ -111,10 +111,10 @@ _start.higher:
     jl _start.higher
 
 _start.bootinfo:
-        ; Locate the bootinfo structures so we can map those
-        ; along with the kernel
+    ; Locate the bootinfo structures so we can map those
+    ; along with the kernel
 
-        ; Check for stivale2 magic
+    ; Check for stivale2 magic
     xor eax, eax
     mov eax, dword [multiboot_magic]
     cmp eax, STIVALE2_MAGIC
@@ -161,7 +161,6 @@ _start.trymb2:
     pop eax
 
 _start.markboot:
-
     mov ecx, eax
     shr ecx, PAGE_SHIFT
     and ecx, 0x3ff
@@ -206,7 +205,6 @@ _start.badboot:
     jmp _start.failhang
 
 _start.badinfo:
-
     ; panic because we can't find the length
     ; of the bootloader info area
     push bad_info_msg

--- a/kernel/arch/i386/boot/boot.S
+++ b/kernel/arch/i386/boot/boot.S
@@ -11,6 +11,10 @@ extern _fini
 extern kernel_main
 ; minimal panic function that works in most situations
 extern early_panic
+; paging helper for stivale2 bootloader info
+extern stivale2_mmap_helper
+; paging helper for multiboot2 bootloader info
+extern multiboot2_mmap_helper
 
 extern _KERNEL_BASE
 extern _KERNEL_START
@@ -28,6 +32,10 @@ PAGE_SIZE equ 4096
 PAGE_SHIFT equ 12                       ; 2^12 = 4096 = PAGE_SIZE
 PAGE_PERM equ 3                         ; default page permissions: present, read/write
 STACK_SIZE equ 4*PAGE_SIZE              ; initial kernel stack space size of 16k
+
+; Magic numbers for pre-mapping
+STIVALE2_MAGIC equ 'stv2'
+MULTIBOOT2_MAGIC equ 0x36d76289
 
 ; Text section of our executable. See linker.ld
 ; This is the kernel entry point
@@ -102,6 +110,67 @@ _start.higher:
     cmp eax, _KERNEL_END ; are we done mapping in the kernel?
     jl _start.higher
 
+_start.bootinfo:
+        ; Locate the bootinfo structures so we can map those
+        ; along with the kernel
+
+        ; Check for stivale2 magic
+    xor eax, eax
+    mov eax, dword [multiboot_magic]
+    cmp eax, STIVALE2_MAGIC
+    jne _start.trymb2      ; nope, try multiboot2
+    xor eax, eax
+    mov eax, dword [multiboot_info]
+    add eax, 128          ; Skip over the text fields
+    mov edx, [eax]        ; address of stivale2 structures
+    push edx              ; save address for later
+    shr edx, 22           ; get the right directory entry
+    mov eax, bootld_pt    ; bootloader info page table
+    mov [edx * 4 + page_directory], eax
+    or dword [edx * 4 + page_directory], PAGE_PERM
+    pop eax               ; recover address
+    mov ebx, eax          ; save a copy
+    push ebx
+    push eax
+    call stivale2_mmap_helper
+    add ebx, eax
+    cmp eax, 0x00000000   ; If we have zero here, bad news
+    je _start.badinfo
+    pop eax
+    jmp _start.markboot
+
+_start.trymb2:
+    cmp eax, MULTIBOOT2_MAGIC
+    jne _start.badboot    ; no luck, bail
+    xor eax, eax
+    mov eax, dword [multiboot_info]
+    mov edx, [eax]        ; address of multiboot2 structures
+    push edx              ; save address for later
+    shr edx, 22           ; get the right directory entry
+    mov eax, bootld_pt    ; bootloader info page table
+    mov [edx * 4 + page_directory], eax
+    or dword [edx * 4 + page_directory], PAGE_PERM
+    pop eax               ; recover address
+    mov ebx, eax          ; save a copy
+    push ebx
+    push eax
+    call multiboot2_mmap_helper
+    add ebx, eax
+    cmp eax, 0x00000000   ; If we have zero here, bad news
+    je _start.badinfo
+    pop eax
+
+_start.markboot:
+
+    mov ecx, eax
+    shr ecx, PAGE_SHIFT
+    and ecx, 0x3ff
+    mov [ecx * 4 + bootld_pt], eax
+    or dword [ecx * 4 + bootld_pt], PAGE_PERM
+    add eax, PAGE_SIZE
+    cmp eax, ebx
+    jl _start.markboot
+
     mov eax, page_directory
     mov cr3, eax ; load CR3 with our page directory
 
@@ -128,6 +197,22 @@ _start.higher:
 
     ; panic because no SSE :'(
     push no_sse_msg
+    jmp _start.failhang
+
+_start.badboot:
+    ; panic because we don't have proof of
+    ; of a valid bootloader
+    push bad_boot_msg
+    jmp _start.failhang
+
+_start.badinfo:
+
+    ; panic because we can't find the length
+    ; of the bootloader info area
+    push bad_info_msg
+    jmp _start.failhang
+
+_start.failhang:
     call early_panic
 
     ; infinite loop if panic returns
@@ -172,12 +257,15 @@ page_directory: resd 1024    ; should also be page aligned (hopefully)
 lowmem_pt: resd 1024         ; lowmem identity mappings
 kernel_pt: resd 1024         ; our kernel page table mappings
 pages_pt: resd 1024          ; a page table that maps pages that contain page tables
+bootld_pt: resd 1024         ; a page table to hold bootloader structures
 
 section .early_data alloc write
 align 4
 multiboot_magic: dd 0
 multiboot_info: dd 0
 no_sse_msg: db "Error: No SSE support available!", 0
+bad_info_msg: db "Error: Cannot detect bootloader info length!", 0
+bad_boot_msg: db "Error: Cannot detect bootloader!", 0
 
 section .bss alloc write nobits
 align 4

--- a/kernel/arch/i386/boot/boothelp.cpp
+++ b/kernel/arch/i386/boot/boothelp.cpp
@@ -1,0 +1,97 @@
+/**
+ * @file boothelp.cpp
+ * @author James T. Sprinkle (the-grue@hotmail.com)
+ * @brief
+ * @version 0.1
+ * @date 2021-08-07
+ *
+ * @copyright Copyright the Panix Contributors (c) 2021
+ *
+ */
+#include <stdint.h>
+
+#include <multiboot/multiboot2.h>
+#include <stivale/stivale2.h>
+
+extern "C" uint32_t stivale2_mmap_helper(void* baseaddr);
+extern "C" uint32_t multiboot2_mmap_helper(void* baseaddr);
+
+/**
+ *  ___ _   _          _     ___
+ * / __| |_(_)_ ____ _| |___|_  )
+ * \__ \  _| \ V / _` | / -_)/ /
+ * |___/\__|_|\_/\__,_|_\___/___|
+ *
+ * Scan the stivale2 tags to find the reclaimable bootloader
+ * memory map tag that starts at the stivale2 tag base
+ * address.  Return the length found.  We'll memory map
+ * the entire area.
+ *
+ */
+extern "C" uint32_t
+__attribute__ ((section(".early_text")))
+__attribute__((optimize("O0")))
+stivale2_mmap_helper(void* baseaddr)
+{
+    struct stivale2_tag* tag = (struct stivale2_tag*)baseaddr;
+
+    while (tag)
+    {
+        switch(tag->identifier)
+        {
+            case STIVALE2_STRUCT_TAG_MEMMAP_ID:
+            {
+                auto memmap = (struct stivale2_struct_tag_memmap*)tag;
+                for(uint32_t i = 0; i < (uint32_t)memmap->entries; i++)
+                {
+                    switch((uint32_t) memmap->memmap[i].type)
+                    {
+                        case STIVALE2_MMAP_BOOTLOADER_RECLAIMABLE:
+                            if(((uint32_t) memmap->memmap[i].base) == (uint32_t) baseaddr)
+                            {
+                                return (uint32_t) memmap->memmap[i].length;
+                            }
+                            break;
+
+                        default:
+                            break;
+                    }
+                }
+            }
+            default:
+                break;
+        }
+        tag = (struct stivale2_tag*)tag->next;
+    }
+    // If we get here, there's a problem so we will just
+    // return 0 and panic in boot.S
+    return 0;
+}
+
+/*
+ *  __  __      _ _   _ _              _   ___
+ * |  \/  |_  _| | |_(_) |__  ___  ___| |_|_  )
+ * | |\/| | || | |  _| | '_ \/ _ \/ _ \  _|/ /
+ * |_|  |_|\_,_|_|\__|_|_.__/\___/\___/\__/___|
+ *
+ * Multiboot2 has the size of the bootloader info area
+ * right at the beginning, which makes things easier.
+ * Return the length found.  We'll memory map
+ * the entire area.
+ * 
+ */
+
+extern "C" uint32_t
+__attribute__ ((section(".early_text")))
+__attribute__((optimize("O0")))
+multiboot2_mmap_helper(void* baseaddr)
+{
+    struct multiboot_fixed
+    {
+        uint32_t total_size;
+        uint32_t reserved;
+    };
+
+    auto fixed = (struct multiboot_fixed *) baseaddr;
+    return fixed->total_size;
+}

--- a/kernel/arch/i386/boot/boothelp.cpp
+++ b/kernel/arch/i386/boot/boothelp.cpp
@@ -29,37 +29,31 @@ extern "C" uint32_t multiboot2_mmap_helper(void* baseaddr);
  *
  */
 extern "C" uint32_t
-__attribute__ ((section(".early_text")))
-__attribute__((optimize("O0")))
-stivale2_mmap_helper(void* baseaddr)
+    __attribute__((section(".early_text")))
+    __attribute__((optimize("O0")))
+    stivale2_mmap_helper(void* baseaddr)
 {
     struct stivale2_tag* tag = (struct stivale2_tag*)baseaddr;
 
-    while (tag)
-    {
-        switch(tag->identifier)
-        {
-            case STIVALE2_STRUCT_TAG_MEMMAP_ID:
-            {
-                auto memmap = (struct stivale2_struct_tag_memmap*)tag;
-                for(uint32_t i = 0; i < (uint32_t)memmap->entries; i++)
-                {
-                    switch((uint32_t) memmap->memmap[i].type)
-                    {
-                        case STIVALE2_MMAP_BOOTLOADER_RECLAIMABLE:
-                            if(((uint32_t) memmap->memmap[i].base) == (uint32_t) baseaddr)
-                            {
-                                return (uint32_t) memmap->memmap[i].length;
-                            }
-                            break;
-
-                        default:
-                            break;
+    while (tag) {
+        switch (tag->identifier) {
+        case STIVALE2_STRUCT_TAG_MEMMAP_ID: {
+            auto memmap = (struct stivale2_struct_tag_memmap*)tag;
+            for (uint32_t i = 0; i < (uint32_t)memmap->entries; i++) {
+                switch ((uint32_t)memmap->memmap[i].type) {
+                case STIVALE2_MMAP_BOOTLOADER_RECLAIMABLE:
+                    if (((uint32_t)memmap->memmap[i].base) == (uint32_t)baseaddr) {
+                        return (uint32_t)memmap->memmap[i].length;
                     }
+                    break;
+
+                default:
+                    break;
                 }
             }
-            default:
-                break;
+        }
+        default:
+            break;
         }
         tag = (struct stivale2_tag*)tag->next;
     }
@@ -82,16 +76,15 @@ stivale2_mmap_helper(void* baseaddr)
  */
 
 extern "C" uint32_t
-__attribute__ ((section(".early_text")))
-__attribute__((optimize("O0")))
-multiboot2_mmap_helper(void* baseaddr)
+    __attribute__((section(".early_text")))
+    __attribute__((optimize("O0")))
+    multiboot2_mmap_helper(void* baseaddr)
 {
-    struct multiboot_fixed
-    {
+    struct multiboot_fixed {
         uint32_t total_size;
         uint32_t reserved;
     };
 
-    auto fixed = (struct multiboot_fixed *) baseaddr;
+    auto fixed = (struct multiboot_fixed*)baseaddr;
     return fixed->total_size;
 }

--- a/kernel/boot/Handoff.cpp
+++ b/kernel/boot/Handoff.cpp
@@ -15,8 +15,8 @@
 #include <mem/paging.hpp>
 #include <sys/panic.hpp>
 // Generic devices
-#include <dev/tty/tty.hpp>
 #include <dev/serial/rs232.hpp>
+#include <dev/tty/tty.hpp>
 // Bootloaders
 #include <multiboot/multiboot2.h>
 #include <stivale/stivale2.h>
@@ -76,114 +76,100 @@ void Handoff::parseStivale2(Handoff* that, void* handoff)
     struct stivale2_struct* fixed = (struct stivale2_struct*)handoff;
     // Walk the list of tags in the header
     struct stivale2_tag* tag = (struct stivale2_tag*)(fixed->tags);
-    while (tag)
-    {
-/* -- GRUE REMOVE
-        // TODO: Find a way around this when the new memory manager code is done.
-        uintptr_t page = ((uintptr_t)tag & PAGE_ALIGN);
-        map_kernel_page(VADDR(page), page);
- */
-        // Follows the tag list order in stivale2.h
-        switch(tag->identifier)
-        {
+    while (tag) {
+         // Follows the tag list order in stivale2.h
+        switch (tag->identifier) {
 #ifdef DEBUG
-            case STIVALE2_STRUCT_TAG_MEMMAP_ID:
-            {
-                auto memmap = (struct stivale2_struct_tag_memmap*)tag;
-                rs232::printf("Stivale2 memmap found...\n");
-                for(uint32_t i = 0; i < (uint32_t)memmap->entries; i++)
-                {
-                    switch((uint32_t) memmap->memmap[i].type)
-                    {
-                        case STIVALE2_MMAP_USABLE:
-                            rs232::printf("Stivale2 USABLE memory: ");
-                            break;
+        case STIVALE2_STRUCT_TAG_MEMMAP_ID: {
+            auto memmap = (struct stivale2_struct_tag_memmap*)tag;
+            rs232::printf("Stivale2 memmap found...\n");
+            for (uint32_t i = 0; i < (uint32_t)memmap->entries; i++) {
+                switch ((uint32_t)memmap->memmap[i].type) {
+                case STIVALE2_MMAP_USABLE:
+                    rs232::printf("Stivale2 USABLE memory: ");
+                    break;
 
-                        case STIVALE2_MMAP_RESERVED:
-                            rs232::printf("Stivale2 RESERVED memory: ");
-                            break;
+                case STIVALE2_MMAP_RESERVED:
+                    rs232::printf("Stivale2 RESERVED memory: ");
+                    break;
 
-                        case STIVALE2_MMAP_ACPI_RECLAIMABLE:
-                            rs232::printf("Stivale2 ACPI_RECLAIMABLE memory: ");
-                            break;
+                case STIVALE2_MMAP_ACPI_RECLAIMABLE:
+                    rs232::printf("Stivale2 ACPI_RECLAIMABLE memory: ");
+                    break;
 
-                        case STIVALE2_MMAP_ACPI_NVS:
-                            rs232::printf("Stivale2 ACPI_NVS memory: ");
-                            break;
+                case STIVALE2_MMAP_ACPI_NVS:
+                    rs232::printf("Stivale2 ACPI_NVS memory: ");
+                    break;
 
-                        case STIVALE2_MMAP_BAD_MEMORY:
-                            rs232::printf("Stivale2 BAD memory: ");
-                            break;
+                case STIVALE2_MMAP_BAD_MEMORY:
+                    rs232::printf("Stivale2 BAD memory: ");
+                    break;
 
-                        case STIVALE2_MMAP_BOOTLOADER_RECLAIMABLE:
-                            rs232::printf("Stivale2 BOOTLOADER_RECLAIMABLE memory: ");
-                            break;
+                case STIVALE2_MMAP_BOOTLOADER_RECLAIMABLE:
+                    rs232::printf("Stivale2 BOOTLOADER_RECLAIMABLE memory: ");
+                    break;
 
-                        case STIVALE2_MMAP_KERNEL_AND_MODULES:
-                            rs232::printf("Stivale2 KERNEL_AND_MODULES memory: ");
-                            break;
+                case STIVALE2_MMAP_KERNEL_AND_MODULES:
+                    rs232::printf("Stivale2 KERNEL_AND_MODULES memory: ");
+                    break;
 
-			default:
-                            rs232::printf("Unknown Memory Type 0x%08X: ", memmap->memmap[i].type);
-                            break;
-                    }
-                    rs232::printf("Base: 0x%08X, Length: 0x%08X\n", (uint32_t) memmap->memmap[i].base,
-                        (uint32_t) memmap->memmap[i].length);
+                default:
+                    rs232::printf("Unknown Memory Type 0x%08X: ", memmap->memmap[i].type);
+                    break;
                 }
-                break;
+                rs232::printf("Base: 0x%08X, Length: 0x%08X\n", (uint32_t)memmap->memmap[i].base,
+                    (uint32_t)memmap->memmap[i].length);
             }
+            break;
+        }
 #endif
-            case STIVALE2_STRUCT_TAG_CMDLINE_ID:
-            {
-                auto cmdline = (struct stivale2_struct_tag_cmdline*)tag;
-                rs232::printf("Stivale2 cmdline: '%s'\n", (const char *)cmdline->cmdline);
-                that->_cmdline = (char *)(cmdline->cmdline);
-                break;
-            }
-            case STIVALE2_STRUCT_TAG_FRAMEBUFFER_ID:
-            {
-                auto framebuffer = (struct stivale2_struct_tag_framebuffer*)tag;
-                rs232::printf("Stivale2 framebuffer:\n");
-                rs232::printf("\tAddress: 0x%08X\n", framebuffer->framebuffer_addr);
-                rs232::printf("\tResolution: %ix%ix%i\n",
-                    framebuffer->framebuffer_width,
-                    framebuffer->framebuffer_height,
-                    framebuffer->framebuffer_bpp);
-                rs232::printf("\tPixel format:\n"
-                             "\t\tRed size:    %u\n"
-                             "\t\tRed shift:   %u\n"
-                             "\t\tGreen size:  %u\n"
-                             "\t\tGreen shift: %u\n"
-                             "\t\tBlue size:   %u\n"
-                             "\t\tBlue shift:  %u\n",
-                             framebuffer->red_mask_size,
-                             framebuffer->red_mask_shift,
-                             framebuffer->green_mask_size,
-                             framebuffer->green_mask_shift,
-                             framebuffer->blue_mask_size,
-                             framebuffer->blue_mask_shift);
-                // Initialize the framebuffer information
-                that->_fbInfo = fb::FramebufferInfo(
-                    framebuffer->framebuffer_width,
-                    framebuffer->framebuffer_height,
-                    framebuffer->framebuffer_bpp,
-                    framebuffer->framebuffer_pitch,
-                    reinterpret_cast<void*>(framebuffer->framebuffer_addr),
-                    static_cast<fb::FramebufferMemoryModel>(framebuffer->memory_model),
-                    framebuffer->red_mask_size,
-                    framebuffer->red_mask_shift,
-                    framebuffer->green_mask_size,
-                    framebuffer->green_mask_shift,
-                    framebuffer->blue_mask_size,
-                    framebuffer->blue_mask_shift
-                );
-                break;
-            }
-            default:
-            {
-                //rs232::printf("Unknown Stivale2 tag: 0x%016X\n", tag->identifier);
-                break;
-            }
+        case STIVALE2_STRUCT_TAG_CMDLINE_ID: {
+            auto cmdline = (struct stivale2_struct_tag_cmdline*)tag;
+            rs232::printf("Stivale2 cmdline: '%s'\n", (const char*)cmdline->cmdline);
+            that->_cmdline = (char*)(cmdline->cmdline);
+            break;
+        }
+        case STIVALE2_STRUCT_TAG_FRAMEBUFFER_ID: {
+            auto framebuffer = (struct stivale2_struct_tag_framebuffer*)tag;
+            rs232::printf("Stivale2 framebuffer:\n");
+            rs232::printf("\tAddress: 0x%08X\n", framebuffer->framebuffer_addr);
+            rs232::printf("\tResolution: %ix%ix%i\n",
+                framebuffer->framebuffer_width,
+                framebuffer->framebuffer_height,
+                framebuffer->framebuffer_bpp);
+            rs232::printf("\tPixel format:\n"
+                          "\t\tRed size:    %u\n"
+                          "\t\tRed shift:   %u\n"
+                          "\t\tGreen size:  %u\n"
+                          "\t\tGreen shift: %u\n"
+                          "\t\tBlue size:   %u\n"
+                          "\t\tBlue shift:  %u\n",
+                framebuffer->red_mask_size,
+                framebuffer->red_mask_shift,
+                framebuffer->green_mask_size,
+                framebuffer->green_mask_shift,
+                framebuffer->blue_mask_size,
+                framebuffer->blue_mask_shift);
+            // Initialize the framebuffer information
+            that->_fbInfo = fb::FramebufferInfo(
+                framebuffer->framebuffer_width,
+                framebuffer->framebuffer_height,
+                framebuffer->framebuffer_bpp,
+                framebuffer->framebuffer_pitch,
+                reinterpret_cast<void*>(framebuffer->framebuffer_addr),
+                static_cast<fb::FramebufferMemoryModel>(framebuffer->memory_model),
+                framebuffer->red_mask_size,
+                framebuffer->red_mask_shift,
+                framebuffer->green_mask_size,
+                framebuffer->green_mask_shift,
+                framebuffer->blue_mask_size,
+                framebuffer->blue_mask_shift);
+            break;
+        }
+        default: {
+            //rs232::printf("Unknown Stivale2 tag: 0x%016X\n", tag->identifier);
+            break;
+        }
         }
 
         tag = (struct stivale2_tag*)tag->next;
@@ -198,79 +184,64 @@ void Handoff::parseStivale2(Handoff* that, void* handoff)
  * |_|  |_|\_,_|_|\__|_|_.__/\___/\___/\__/___|
  */
 
-struct multiboot_fixed
-{
+struct multiboot_fixed {
     uint32_t total_size;
     uint32_t reserved;
 };
 
 void Handoff::parseMultiboot2(Handoff* that, void* handoff)
 {
-    auto fixed = (struct multiboot_fixed *) handoff;
-/* -- GRUE REMOVE
-    // TODO: Find a way around this when the new memory manager code is done.
-    for (uintptr_t page = ((uintptr_t)handoff & PAGE_ALIGN) + PAGE_SIZE;
-         page <= (((uintptr_t)handoff + fixed->total_size) & PAGE_ALIGN);
-         page += PAGE_SIZE) {
-        rs232::printf("Mapping bootinfo at 0x%08x\n", page);
-        map_kernel_page(VADDR(page), page);
-    }
- */
-    struct multiboot_tag *tag = (struct multiboot_tag*)((uintptr_t)fixed + sizeof(struct multiboot_fixed));
+    auto fixed = (struct multiboot_fixed*)handoff;
+    struct multiboot_tag* tag = (struct multiboot_tag*)((uintptr_t)fixed + sizeof(struct multiboot_fixed));
     while (tag->type != MULTIBOOT_TAG_TYPE_END) {
-        switch (tag->type)
-        {
-            case MULTIBOOT_TAG_TYPE_CMDLINE:
-            {
-                auto cmdline = (struct multiboot_tag_string *) tag;
-                rs232::printf("Multiboot2 cmdline: '%s'\n", cmdline->string);
-                that->_cmdline = (char *)(cmdline->string);
-                break;
-            }
-            case MULTIBOOT_TAG_TYPE_FRAMEBUFFER:
-            {
-                auto framebuffer = (struct multiboot_tag_framebuffer *)tag;
-                rs232::printf("Multiboot2 framebuffer:\n");
-                rs232::printf("\tAddress: 0x%08X\n", framebuffer->common.framebuffer_addr);
-                rs232::printf("\tResolution: %ix%ix%i\n",
-                    framebuffer->common.framebuffer_width,
-                    framebuffer->common.framebuffer_height,
-                    (framebuffer->common.framebuffer_bpp));
-                rs232::printf("\tPixel format:\n"
-                             "\t\tRed size:    %u\n"
-                             "\t\tRed shift:   %u\n"
-                             "\t\tGreen size:  %u\n"
-                             "\t\tGreen shift: %u\n"
-                             "\t\tBlue size:   %u\n"
-                             "\t\tBlue shift:  %u\n",
-                             framebuffer->framebuffer_red_mask_size,
-                             framebuffer->framebuffer_red_field_position,
-                             framebuffer->framebuffer_green_mask_size,
-                             framebuffer->framebuffer_green_field_position,
-                             framebuffer->framebuffer_blue_mask_size,
-                             framebuffer->framebuffer_blue_field_position);
-                // Initialize the framebuffer information
-                that->_fbInfo = fb::FramebufferInfo(
-                    framebuffer->common.framebuffer_width,
-                    framebuffer->common.framebuffer_height,
-                    framebuffer->common.framebuffer_bpp,
-                    framebuffer->common.framebuffer_pitch,
-                    (void*)framebuffer->common.framebuffer_addr,
-                    (fb::FramebufferMemoryModel)framebuffer->common.framebuffer_type,
-                    framebuffer->framebuffer_red_mask_size,
-                    framebuffer->framebuffer_red_field_position,
-                    framebuffer->framebuffer_green_mask_size,
-                    framebuffer->framebuffer_green_field_position,
-                    framebuffer->framebuffer_blue_mask_size,
-                    framebuffer->framebuffer_blue_field_position
-                );
-                break;
-            }
-            default:
-            {
-                //rs232::printf("Unknown Multiboot2 tag: 0x%08X\n", tag->type);
-                break;
-            }
+        switch (tag->type) {
+        case MULTIBOOT_TAG_TYPE_CMDLINE: {
+            auto cmdline = (struct multiboot_tag_string*)tag;
+            rs232::printf("Multiboot2 cmdline: '%s'\n", cmdline->string);
+            that->_cmdline = (char*)(cmdline->string);
+            break;
+        }
+        case MULTIBOOT_TAG_TYPE_FRAMEBUFFER: {
+            auto framebuffer = (struct multiboot_tag_framebuffer*)tag;
+            rs232::printf("Multiboot2 framebuffer:\n");
+            rs232::printf("\tAddress: 0x%08X\n", framebuffer->common.framebuffer_addr);
+            rs232::printf("\tResolution: %ix%ix%i\n",
+                framebuffer->common.framebuffer_width,
+                framebuffer->common.framebuffer_height,
+                (framebuffer->common.framebuffer_bpp));
+            rs232::printf("\tPixel format:\n"
+                          "\t\tRed size:    %u\n"
+                          "\t\tRed shift:   %u\n"
+                          "\t\tGreen size:  %u\n"
+                          "\t\tGreen shift: %u\n"
+                          "\t\tBlue size:   %u\n"
+                          "\t\tBlue shift:  %u\n",
+                framebuffer->framebuffer_red_mask_size,
+                framebuffer->framebuffer_red_field_position,
+                framebuffer->framebuffer_green_mask_size,
+                framebuffer->framebuffer_green_field_position,
+                framebuffer->framebuffer_blue_mask_size,
+                framebuffer->framebuffer_blue_field_position);
+            // Initialize the framebuffer information
+            that->_fbInfo = fb::FramebufferInfo(
+                framebuffer->common.framebuffer_width,
+                framebuffer->common.framebuffer_height,
+                framebuffer->common.framebuffer_bpp,
+                framebuffer->common.framebuffer_pitch,
+                (void*)framebuffer->common.framebuffer_addr,
+                (fb::FramebufferMemoryModel)framebuffer->common.framebuffer_type,
+                framebuffer->framebuffer_red_mask_size,
+                framebuffer->framebuffer_red_field_position,
+                framebuffer->framebuffer_green_mask_size,
+                framebuffer->framebuffer_green_field_position,
+                framebuffer->framebuffer_blue_mask_size,
+                framebuffer->framebuffer_blue_field_position);
+            break;
+        }
+        default: {
+            //rs232::printf("Unknown Multiboot2 tag: 0x%08X\n", tag->type);
+            break;
+        }
         }
         // move to the next tag, aligning if necessary
         tag = (struct multiboot_tag*)(((uintptr_t)tag + tag->size + 7) & ~((uintptr_t)7));

--- a/kernel/boot/Handoff.cpp
+++ b/kernel/boot/Handoff.cpp
@@ -78,12 +78,61 @@ void Handoff::parseStivale2(Handoff* that, void* handoff)
     struct stivale2_tag* tag = (struct stivale2_tag*)(fixed->tags);
     while (tag)
     {
+/* -- GRUE REMOVE
         // TODO: Find a way around this when the new memory manager code is done.
         uintptr_t page = ((uintptr_t)tag & PAGE_ALIGN);
         map_kernel_page(VADDR(page), page);
+ */
         // Follows the tag list order in stivale2.h
         switch(tag->identifier)
         {
+#ifdef DEBUG
+            case STIVALE2_STRUCT_TAG_MEMMAP_ID:
+            {
+                auto memmap = (struct stivale2_struct_tag_memmap*)tag;
+                rs232::printf("Stivale2 memmap found...\n");
+                for(uint32_t i = 0; i < (uint32_t)memmap->entries; i++)
+                {
+                    switch((uint32_t) memmap->memmap[i].type)
+                    {
+                        case STIVALE2_MMAP_USABLE:
+                            rs232::printf("Stivale2 USABLE memory: ");
+                            break;
+
+                        case STIVALE2_MMAP_RESERVED:
+                            rs232::printf("Stivale2 RESERVED memory: ");
+                            break;
+
+                        case STIVALE2_MMAP_ACPI_RECLAIMABLE:
+                            rs232::printf("Stivale2 ACPI_RECLAIMABLE memory: ");
+                            break;
+
+                        case STIVALE2_MMAP_ACPI_NVS:
+                            rs232::printf("Stivale2 ACPI_NVS memory: ");
+                            break;
+
+                        case STIVALE2_MMAP_BAD_MEMORY:
+                            rs232::printf("Stivale2 BAD memory: ");
+                            break;
+
+                        case STIVALE2_MMAP_BOOTLOADER_RECLAIMABLE:
+                            rs232::printf("Stivale2 BOOTLOADER_RECLAIMABLE memory: ");
+                            break;
+
+                        case STIVALE2_MMAP_KERNEL_AND_MODULES:
+                            rs232::printf("Stivale2 KERNEL_AND_MODULES memory: ");
+                            break;
+
+			default:
+                            rs232::printf("Unknown Memory Type 0x%08X: ", memmap->memmap[i].type);
+                            break;
+                    }
+                    rs232::printf("Base: 0x%08X, Length: 0x%08X\n", (uint32_t) memmap->memmap[i].base,
+                        (uint32_t) memmap->memmap[i].length);
+                }
+                break;
+            }
+#endif
             case STIVALE2_STRUCT_TAG_CMDLINE_ID:
             {
                 auto cmdline = (struct stivale2_struct_tag_cmdline*)tag;

--- a/kernel/boot/Handoff.cpp
+++ b/kernel/boot/Handoff.cpp
@@ -207,6 +207,7 @@ struct multiboot_fixed
 void Handoff::parseMultiboot2(Handoff* that, void* handoff)
 {
     auto fixed = (struct multiboot_fixed *) handoff;
+/* -- GRUE REMOVE
     // TODO: Find a way around this when the new memory manager code is done.
     for (uintptr_t page = ((uintptr_t)handoff & PAGE_ALIGN) + PAGE_SIZE;
          page <= (((uintptr_t)handoff + fixed->total_size) & PAGE_ALIGN);
@@ -214,6 +215,7 @@ void Handoff::parseMultiboot2(Handoff* that, void* handoff)
         rs232::printf("Mapping bootinfo at 0x%08x\n", page);
         map_kernel_page(VADDR(page), page);
     }
+ */
     struct multiboot_tag *tag = (struct multiboot_tag*)((uintptr_t)fixed + sizeof(struct multiboot_fixed));
     while (tag->type != MULTIBOOT_TAG_TYPE_END) {
         switch (tag->type)

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -9,12 +9,12 @@
  *
  */
 // System library functions
+#include <lib/stdio.hpp>
+#include <lib/string.hpp>
+#include <lib/time.hpp>
 #include <stdint.h>
 #include <sys/panic.hpp>
 #include <sys/tasks.hpp>
-#include <lib/string.hpp>
-#include <lib/stdio.hpp>
-#include <lib/time.hpp>
 // Bootloader
 #include <boot/Handoff.hpp>
 // Memory management & paging
@@ -23,17 +23,17 @@
 // Architecture specific code
 #include <arch/arch.hpp>
 // Generic devices
-#include <dev/vga/fb.hpp>
-#include <dev/vga/graphics.hpp>
-#include <dev/tty/tty.hpp>
 #include <dev/kbd/kbd.hpp>
 #include <dev/rtc/rtc.hpp>
-#include <dev/spkr/spkr.hpp>
 #include <dev/serial/rs232.hpp>
+#include <dev/spkr/spkr.hpp>
+#include <dev/tty/tty.hpp>
+#include <dev/vga/fb.hpp>
+#include <dev/vga/graphics.hpp>
 // Apps
+#include <apps/animation.hpp>
 #include <apps/primes.hpp>
 #include <apps/spinner.hpp>
-#include <apps/animation.hpp>
 // Debug
 #include <lib/assert.hpp>
 // Meta
@@ -43,16 +43,8 @@ static Boot::Handoff handoff;
 static void kernel_print_splash();
 static void kernel_boot_tone();
 
-static void boot_init(void *boot_info, uint32_t magic)
+static void boot_init(void* boot_info, uint32_t magic)
 {
-/* -- GRUE REMOVE
-    // Map in bootloader information
-    // TODO: Find a way to avoid this until after parsing
-    if (boot_info != NULL) {
-        uintptr_t page = (uintptr_t)boot_info & PAGE_ALIGN;
-        map_kernel_page(VADDR(page), page);
-    }
- */
     // Parse the bootloader information into common format
     handoff = Boot::Handoff(boot_info, magic);
     // Ensure handoff is no longer default initialized
@@ -63,34 +55,29 @@ static void boot_init(void *boot_info, uint32_t magic)
  * @brief This is the Panix kernel entry point. This function is called directly from the
  * assembly written in boot.S located in arch/i386/boot.S.
  */
-void kernel_main(void *boot_info, uint32_t magic) {
+void kernel_main(void* boot_info, uint32_t magic)
+{
     // Print the splash screen to show we've booted into the kernel properly.
     kernel_print_splash();
     // Install the GDT
     interrupts_disable();
-    gdt_install();                  // Initialize the Global Descriptor Table
-    isr_install();                  // Initialize Interrupt Service Requests
-    rs232::init(RS_232_COM1);        // RS232 Serial
-    boot_init(boot_info, magic);    // Initialize bootloader information
-    paging_init(0);                 // Initialize paging service (0 is placeholder)
-/* -- GRUE REMOVE
-//    boot_init(boot_info, magic);    // Initialize bootloader information
-                                    // TODO: Bootloader should be first but currently
-                                    //       requires paging, which should come after
-                                    //       boot information is parsed.
- */
+    gdt_install();               // Initialize the Global Descriptor Table
+    isr_install();               // Initialize Interrupt Service Requests
+    rs232::init(RS_232_COM1);    // RS232 Serial
+    boot_init(boot_info, magic); // Initialize bootloader information
+    paging_init(0);              // Initialize paging service (0 is placeholder)
     fb::init(handoff.getFramebufferInfo());
-    kbd_init();                     // Initialize PS/2 Keyboard
-    rtc_init();                     // Initialize Real Time Clock
-    timer_init(1000);               // Programmable Interrupt Timer (1ms)
+    kbd_init();       // Initialize PS/2 Keyboard
+    rtc_init();       // Initialize Real Time Clock
+    timer_init(1000); // Programmable Interrupt Timer (1ms)
     // Enable interrupts now that we're out of a critical area
     interrupts_enable();
     // Print some info to show we did things right
     Time::TimeDescriptor time;
     time.printDate();
     // Get the CPU vendor and model data to print
-    const char *vendor = cpu_get_vendor();
-    const char *model = cpu_get_model();
+    const char* vendor = cpu_get_vendor();
+    const char* model = cpu_get_model();
     kprintf(DBG_INFO "%s %s\n", vendor, model);
     // Print out the CPU vendor info
     rs232::printf("%s\n%s\n", vendor, model);
@@ -109,7 +96,8 @@ void kernel_main(void *boot_info, uint32_t magic) {
     PANIC("Kernel terminated unexpectedly!");
 }
 
-static void kernel_print_splash() {
+static void kernel_print_splash()
+{
     tty_clear();
     kprintf(
         "\033[93m"
@@ -119,17 +107,13 @@ static void kernel_print_splash() {
         "\033[0m",
         VER_NAME,
         (
-            ((__DATE__)[7] - '0') * 1000 + \
-            ((__DATE__)[8] - '0') * 100  + \
-            ((__DATE__)[9] - '0') * 10   + \
-            ((__DATE__)[10] - '0') * 1     \
-        ),
-        REPO_URL
-    );
+            ((__DATE__)[7] - '0') * 1000 + ((__DATE__)[8] - '0') * 100 + ((__DATE__)[9] - '0') * 10 + ((__DATE__)[10] - '0') * 1),
+        REPO_URL);
     kprintf("Commit %s (v%s.%s.%s) built on %s at %s.\n\n", COMMIT, VER_MAJOR, VER_MINOR, VER_PATCH, __DATE__, __TIME__);
 }
 
-static void kernel_boot_tone() {
+static void kernel_boot_tone()
+{
     // Beep beep!
     spkr_beep(1000, 50);
     sleep(100);

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -67,9 +67,9 @@ void kernel_main(void* boot_info, uint32_t magic)
     boot_init(boot_info, magic); // Initialize bootloader information
     paging_init(0);              // Initialize paging service (0 is placeholder)
     fb::init(handoff.getFramebufferInfo());
-    kbd_init();       // Initialize PS/2 Keyboard
-    rtc_init();       // Initialize Real Time Clock
-    timer_init(1000); // Programmable Interrupt Timer (1ms)
+    kbd_init();                  // Initialize PS/2 Keyboard
+    rtc_init();                  // Initialize Real Time Clock
+    timer_init(1000);            // Programmable Interrupt Timer (1ms)
     // Enable interrupts now that we're out of a critical area
     interrupts_enable();
     // Print some info to show we did things right
@@ -107,7 +107,11 @@ static void kernel_print_splash()
         "\033[0m",
         VER_NAME,
         (
-            ((__DATE__)[7] - '0') * 1000 + ((__DATE__)[8] - '0') * 100 + ((__DATE__)[9] - '0') * 10 + ((__DATE__)[10] - '0') * 1),
+            ((__DATE__)[7] - '0') * 1000 + \
+            ((__DATE__)[8] - '0') * 100  + \
+            ((__DATE__)[9] - '0') * 10   + \
+            ((__DATE__)[10] - '0') * 1     \
+        ),
         REPO_URL);
     kprintf("Commit %s (v%s.%s.%s) built on %s at %s.\n\n", COMMIT, VER_MAJOR, VER_MINOR, VER_PATCH, __DATE__, __TIME__);
 }

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -45,12 +45,14 @@ static void kernel_boot_tone();
 
 static void boot_init(void *boot_info, uint32_t magic)
 {
+/* -- GRUE REMOVE
     // Map in bootloader information
     // TODO: Find a way to avoid this until after parsing
     if (boot_info != NULL) {
         uintptr_t page = (uintptr_t)boot_info & PAGE_ALIGN;
         map_kernel_page(VADDR(page), page);
     }
+ */
     // Parse the bootloader information into common format
     handoff = Boot::Handoff(boot_info, magic);
     // Ensure handoff is no longer default initialized
@@ -69,11 +71,14 @@ void kernel_main(void *boot_info, uint32_t magic) {
     gdt_install();                  // Initialize the Global Descriptor Table
     isr_install();                  // Initialize Interrupt Service Requests
     rs232::init(RS_232_COM1);        // RS232 Serial
-    paging_init(0);                 // Initialize paging service (0 is placeholder)
     boot_init(boot_info, magic);    // Initialize bootloader information
+    paging_init(0);                 // Initialize paging service (0 is placeholder)
+/* -- GRUE REMOVE
+//    boot_init(boot_info, magic);    // Initialize bootloader information
                                     // TODO: Bootloader should be first but currently
                                     //       requires paging, which should come after
                                     //       boot information is parsed.
+ */
     fb::init(handoff.getFramebufferInfo());
     kbd_init();                     // Initialize PS/2 Keyboard
     rtc_init();                     // Initialize Real Time Clock


### PR DESCRIPTION
Added mapping code for bootloader info blocks into the boot.S code with help from boothelp.cpp.  This allows for parsing of bootloader info prior to paging.  Reference Issue #278 

There are commented out blocks in Handoff.cpp and main.cpp to be removed after verification this is what you want and when the PR is ready for merge.
