### PR TITLE
Change docs.yml dispatch secret to use PAT

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Emit repository_dispatch
         uses: mvasigh/dispatch-action@main
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DOCS_PAT }}
           repo: docs
           owner: XyrisOS
           event_type: push_dev


### PR DESCRIPTION
Turns out `secrets.GITHUB_TOKEN` won't work.