### PR TITLE
(Partially) Resolve: Add Missing Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [LICENSE](https://github.com/XyrisOS/xyris/blob/stable/LICENSE) for details.
 <a href="https://github.com/XyrisOS/xyris/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=XyrisOS/xyris" />
 </a>
-</br>
+<br>
 
 ## Third Party Projects
 * [Limine Bootloader](https://github.com/limine-bootloader/limine)

--- a/kernel/arch/README.md
+++ b/kernel/arch/README.md
@@ -1,5 +1,0 @@
-## System Architectures
-A lot of the functions in the kernel folder (basically 100% of them) assume we're working with an Intel/AMD i386-style CPU.
-All code that makes this assumption should go into the i386 folder and all code that enables long mode (x64 execution) should go in an x86_64 folder. Likewise, any ARM specific code should go in an armvX folder where X is the ARM processor version.
-
-There's still some cleanup to do in terms of moving processor specific code into this folder, but we'll do that eventually.

--- a/kernel/arch/i386/arch-i386.cpp
+++ b/kernel/arch/i386/arch-i386.cpp
@@ -1,5 +1,5 @@
 /**
- * @file i386.cpp
+ * @file arch-i386.cpp
  * @author Keeton Feavel (keetonfeavel@cedarville.edu)
  * @brief i386 architecture implementation of arch.hpp
  * @version 0.1

--- a/kernel/arch/i386/gdt.hpp
+++ b/kernel/arch/i386/gdt.hpp
@@ -1,5 +1,5 @@
 /**
- * @file GlobalDescriptorTable.hpp
+ * @file gdt.hpp
  * @author Keeton Feavel (keetonfeavel@cedarville.edu)
  * @brief The Global Descriptor Table (GDT) is specific to the IA32 architecture.
  * It contains entries telling the CPU about memory segments.

--- a/kernel/arch/i386/isr.hpp
+++ b/kernel/arch/i386/isr.hpp
@@ -130,7 +130,7 @@ void isr_install();
  *
  * @param r Register information struct
  */
-extern "C" void isr_handler(struct registers* t);
+extern "C" void isr_handler(struct registers* r);
 
 /**
  * @brief

--- a/kernel/arch/i386/ports.hpp
+++ b/kernel/arch/i386/ports.hpp
@@ -1,5 +1,5 @@
 /**
- * @file Port.hpp
+ * @file ports.hpp
  * @author Keeton Feavel (keetonfeavel@cedarville.edu)
  * @brief Ports header file. Provides inline functions
  * for getting and setting values at different ports.

--- a/kernel/dev/graphics/console.cpp
+++ b/kernel/dev/graphics/console.cpp
@@ -1,5 +1,5 @@
 /**
- * @file tty.cpp
+ * @file console.cpp
  * @author Keeton Feavel (keetonfeavel@cedarville.edu)
  * @brief Framebuffer console
  * @version 0.3

--- a/kernel/dev/graphics/framebuffer.cpp
+++ b/kernel/dev/graphics/framebuffer.cpp
@@ -1,5 +1,5 @@
 /**
- * @file fb.cpp
+ * @file framebuffer.cpp
  * @author Keeton Feavel (keetonfeavel@cedarville.edu)
  * @brief
  * @version 0.1

--- a/kernel/dev/graphics/framebuffer.hpp
+++ b/kernel/dev/graphics/framebuffer.hpp
@@ -1,5 +1,5 @@
 /**
- * @file fb.cpp
+ * @file framebuffer.cpp
  * @author Keeton Feavel (keetonfeavel@cedarville.edu)
  * @brief
  * @version 0.1

--- a/kernel/entry.cpp
+++ b/kernel/entry.cpp
@@ -1,5 +1,5 @@
 /**
- * @file main.cpp
+ * @file entry.cpp
  * @author Keeton Feavel (keetonfeavel@cedarville.edu)
  * @brief The entry point into the Xyris kernel.
  * @version 0.3

--- a/kernel/lib/mutex.hpp
+++ b/kernel/lib/mutex.hpp
@@ -15,12 +15,15 @@
 
 class Mutex {
 public:
+    /**
+     * @brief Construct a new Mutex object
+     *
+     * @param name Mutex name (for debugging / printing)
+     */
     Mutex(const char* name = nullptr);
     /**
      * @brief Destroys a mutex and removes it from memory.
      *
-     * @param mutex Reference mutex
-     * @return int Returns 0 on success and -1 on error.
      */
     ~Mutex();
     /**

--- a/kernel/lib/rand.hpp
+++ b/kernel/lib/rand.hpp
@@ -21,13 +21,13 @@
 /**
  * @brief Return a random value
  *
- * @param
- * @return int random value
+ * @return int Value from random number generator
  */
 int rand(void);
+
 /**
  * @brief Set a seed to rand
  *
- * @param seed a number to set seed
+ * @param seed Random number generator seed
  */
 void srand(unsigned int seed);

--- a/kernel/lib/semaphore.hpp
+++ b/kernel/lib/semaphore.hpp
@@ -26,10 +26,8 @@ public:
      * @param share Boolean value indicating whether the semaphore
      * should be shared amongst threads or will be used within one thread
      * exclusively.
-     * @param name Name of the mutex (for debugging tasks)
-     * @return int Returns 0 if the semaphore was initialized successfully.
+     * @param name Semaphore name (for debugging / printing)
      */
-
     Semaphore(uint32_t val, bool share, const char* name = nullptr);
     /**
      * @brief Destroys a semaphore by removing it from memory.

--- a/kernel/lib/string.hpp
+++ b/kernel/lib/string.hpp
@@ -86,7 +86,7 @@ void itoa(int n, char str[]);
 /**
  * @brief Sets the number of bytes in memory at ptr to the value.
  *
- * @param ptr Pointer to location in memory
+ * @param bufptr Pointer to location in memory
  * @param value Value to be written in memory
  * @param num Number of bytes
  * @return void* Pointer to location in memory

--- a/kernel/mem/paging.cpp
+++ b/kernel/mem/paging.cpp
@@ -27,7 +27,7 @@ static Mutex mutex_paging("paging");
 
 #define MEM_BITMAP_SIZE ((ADDRESS_SPACE_SIZE / PAGE_SIZE) / (sizeof(size_t) * CHAR_BIT))
 
-/* one bit for every page */
+// one bit for every page
 static size_t mem_map[MEM_BITMAP_SIZE] = { 0 };
 static size_t page_map[MEM_BITMAP_SIZE] = { 0 };
 static Bitset mapped_mem = Bitset(mem_map, MEM_BITMAP_SIZE);
@@ -36,7 +36,7 @@ static Bitset mapped_pages = Bitset(page_map, MEM_BITMAP_SIZE);
 static uint32_t             page_dir_addr;
 static struct page_table*   page_dir_virt[PAGE_ENTRIES];
 
-/* both of these must be page aligned for anything to work right at all */
+// both of these must be page aligned for anything to work right at all
 static struct page_directory_entry page_dir_phys[PAGE_ENTRIES] SECTION(".page_tables,\"aw\", @nobits#");
 static struct page_table           page_tables[PAGE_ENTRIES]   SECTION(".page_tables,\"aw\", @nobits#");
 

--- a/kernel/mem/paging.hpp
+++ b/kernel/mem/paging.hpp
@@ -78,7 +78,7 @@ struct page_table_entry
  */
 struct page_table
 {
-   struct page_table_entry pages[1024];
+   struct page_table_entry pages[1024]; // All entries for the table
 };
 
 /**

--- a/kernel/meta/sections.hpp
+++ b/kernel/meta/sections.hpp
@@ -1,5 +1,5 @@
 /**
- * @file kernel.hpp
+ * @file sections.hpp
  * @author Keeton Feavel (keetonfeavel@cedarville.edu)
  * @brief Kernel ELF section definitions
  * @version 0.1

--- a/kernel/sys/tasks.hpp
+++ b/kernel/sys/tasks.hpp
@@ -87,6 +87,7 @@ extern "C" void tasks_switch_to(struct task *task);
  * @param entry Task function entry point
  * @param storage Task stack structure (if NULL, a pointer to the task is returned)
  * @param state Task state structure
+ * @param name Task name (for debugging / printing)
  * @return struct task* Pointer to the created kernel task
  */
 struct task *tasks_new(void (*entry)(void), struct task *storage, task_state state, const char *name);


### PR DESCRIPTION
Addresses part of #303 by fixing all of the doxygen warnings. However, `paging.cpp:41` has a warning seemingly caused by doxygen issue #7886, so that will not go away for now.

This pull request does *not* address the entirety of #303, and therefore it will remain open. However, I am merging this separately since I want to get automatic documentation generation working in CI.