### PR TITLE
Update `xyris-build` version to 3.3.1

### DIFF
--- a/.scuba.yml
+++ b/.scuba.yml
@@ -1,7 +1,7 @@
 # Note: All running tasks have been removed and were migrated to VSCode tasks that
 #       require Qemu to be installed on the host system. This helps reduce the total
 #       size of the Docker image and provide you with more choice.
-image: ghcr.io/xyrisos/xyris-build/xyris-build:3.3.0
+image: ghcr.io/xyrisos/xyris-build/xyris-build:3.3.1
 aliases:
     # Building
     build: make -j$(nproc) all


### PR DESCRIPTION
Adds ARM based Docker image for M1 and other ARM users.