### PR TITLE
Remove `intelliSenseMode` from C/C++ properties

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -13,8 +13,7 @@
                 "${workspaceFolder}/Tests/"
             ],
             "cStandard": "c17",
-            "cppStandard": "c++20",
-            "intelliSenseMode": "gcc-x86"
+            "cppStandard": "c++20"
         }
     ],
     "version": 4


### PR DESCRIPTION
Removes warnings on workspace startup due to system compiler mismatches compared to what the workspace specifies.