### PR TITLE
Build limine-deploy in its own SConscript

### DIFF
--- a/Limine.scons
+++ b/Limine.scons
@@ -1,0 +1,7 @@
+env = Environment(
+    CFLAGS=['-std=c11', '-Wall', '-Wextra', '-Werror'],
+)
+
+limine_deploy = env.Program(source="Thirdparty/limine/limine-deploy.c")
+
+Return("limine_deploy")

--- a/SConstruct
+++ b/SConstruct
@@ -108,11 +108,11 @@ env = Environment(
     ],
 )
 
-limine_env = Environment(
-    CFLAGS=['-std=c11', '-Wall', '-Wextra', '-Werror'],
-    CC='gcc',
+limine_deploy = env.SConscript(
+    "Limine.scons",
+    variant_dir="$BUILD_DIR/limine",
+    duplicate=False,
 )
-limine_deploy = limine_env.Program(source="#Thirdparty/limine/limine-deploy.c")
 env["LIMINE_INSTALL"] = limine_deploy
 
 # ************************


### PR DESCRIPTION
This keeps the build artifacts out of the source tree