### PR TITLE
Secure FBMutex & Improve Locking (Issue #284)

### DIFF
--- a/Kernel/Applications/fbtest.cpp
+++ b/Kernel/Applications/fbtest.cpp
@@ -1,0 +1,25 @@
+/**
+ * @file entry.cpp
+ * @author Amilie Baker(amiliefn@gmail.com)
+ * @brief Simple framebuffer tester.
+ * @version 0.2
+ * @date 2026-05-25
+ *
+ * @copyright Copyright the Xyris Contributors (c) 2026
+ *
+ */
+
+#include <Devices/Graphics/graphics.hpp>
+#include <Arch/i686/timer.hpp>
+#include <Applications/fbtest.hpp>
+
+namespace Apps {
+
+void fbtest()
+{
+    while (true) {
+        sleep(100);
+        Graphics::resetDoubleBuffer();
+    }
+}
+}

--- a/Kernel/Applications/fbtest.hpp
+++ b/Kernel/Applications/fbtest.hpp
@@ -1,0 +1,21 @@
+/**
+ * @file entry.cpp
+ * @author Amilie Baker(amiliefn@gmail.com)
+ * @brief Simple framebuffer tester.
+ * @version 0.3
+ * @date 2026-05-25
+ *
+ * @copyright Copyright the Xyris Contributors (c) 2026
+ *
+ */
+
+#pragma once
+namespace Apps {
+
+/**
+ * @brief Test framebuffer
+ *
+ */
+void fbtest();
+
+}

--- a/Kernel/Devices/Graphics/graphics.cpp
+++ b/Kernel/Devices/Graphics/graphics.cpp
@@ -28,96 +28,120 @@
 #include <Arch/i686/timer.hpp>
 
 namespace Graphics {
+    static Framebuffer* info = NULL;
+    static void* backbuffer = NULL;
+    static bool initialized = false;
 
-static Framebuffer* info = NULL;
-static void* backbuffer = NULL;
-static bool initialized = false;
-
-void init(Framebuffer* fb)
-{
-    // Get the framebuffer info
-    if (!(info = fb))
-        return;
-    // Ensure valid info is provided
-    if (!info->getAddress())
-        return;
-    // Map in the framebuffer
-    Logger::Debug(__func__, "==== MAP FRAMEBUFFER ====");
-    Memory::mapKernelRangeVirtual(Memory::Section(
-        (uintptr_t)info->getAddress(),
-        (info->getPitch() * info->getHeight())
-    ));
-    // Alloc the backbuffer
-    backbuffer = malloc(info->getPitch() * info->getHeight());
-    memcpy(backbuffer, info->getAddress(), info->getPitch() * info->getHeight());
-    initialized = true;
-}
-
-void pixel(uint32_t x, uint32_t y, uint32_t color)
-{
-    // Ensure framebuffer information exists
-    if (!initialized)
-        return;
-    if ((x <= info->getWidth()) && (y <= info->getHeight())) {
-        // Special thanks to the SkiftOS contributors.
-        uint8_t* pixel = (uint8_t*)backbuffer + (y * info->getPitch()) + (x * info->getPixelWidth());
-        // Pixel information
-        pixel[0] = (color >> info->getBlueMaskShift()) & 0xff;  // B
-        pixel[1] = (color >> info->getGreenMaskShift()) & 0xff; // G
-        pixel[2] = (color >> info->getRedMaskShift()) & 0xff;   // R
-        // Additional pixel information
-        if (info->getPixelWidth() == 4)
-            pixel[3] = 0x00;
+    void init(Framebuffer* fb)
+    {
+        // Get the framebuffer info
+        if (!(info = fb))
+            return;
+        // Ensure valid info is provided
+        if (!info->getAddress())
+            return;
+        // Map in the framebuffer
+        Logger::Debug(__func__, "==== MAP FRAMEBUFFER ====");
+        Memory::mapKernelRangeVirtual(Memory::Section(
+            (uintptr_t)info->getAddress(),
+            (info->getPitch() * info->getHeight())
+        ));
+        // Alloc the backbuffer
+        backbuffer = malloc(info->getPitch() * info->getHeight());
+        memcpy(backbuffer, info->getAddress(), info->getPitch() * info->getHeight());
+        initialized = true;
     }
-}
 
-void putrect(uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t color)
-{
-    // Ensure framebuffer information exists
-    if (!initialized)
-        return;
-    for (uint32_t curr_x = x; curr_x <= x + w; curr_x++) {
-        for (uint32_t curr_y = y; curr_y <= y + h; curr_y++) {
-            // Extremely slow but good for debugging
-            pixel(curr_x, curr_y, color);
+    /*
+        I'd advise reading https://en.cppreference.com/cpp/thread/lock_guard for info about Mutex.
+        Saved me a lot of pain and taught it very easy.
+
+        - Ami, 25/05/26
+    */
+
+    Mutex mutex_backbufferAccess("backbuffer");
+
+    static void _pixel(uint32_t x, uint32_t y, uint32_t color)
+    {
+        // Ensure framebuffer information exists
+        if (!initialized)
+            return;
+        if ((x <= info->getWidth()) && (y <= info->getHeight())) {
+            // Special thanks to the SkiftOS contributors.
+            uint8_t* pixel = (uint8_t*)backbuffer + (y * info->getPitch()) + (x * info->getPixelWidth());
+            // Pixel information
+            pixel[0] = (color >> info->getBlueMaskShift()) & 0xff;  // B
+            pixel[1] = (color >> info->getGreenMaskShift()) & 0xff; // G
+            pixel[2] = (color >> info->getRedMaskShift()) & 0xff;   // R
+            // Additional pixel information
+            if (info->getPixelWidth() == 4)
+                pixel[3] = 0x00;
         }
     }
-    // Swap after doing a large operation
-    swap();
-}
 
-/*
-    I'd advise reading https://en.cppreference.com/cpp/thread/lock_guard for info about Mutex.
-    Saved me a lot of pain and taught it very easy.
-
-    - Ami, 25/05/26
-*/
-Mutex mutex_backbufferAccess("backbuffer");
-
-void resetDoubleBuffer()
-{
-    Logger::Debug(__func__, "aquiring lock");
-    RAIIMutex lock(mutex_backbufferAccess);
-    Logger::Debug(__func__, "locked");
-
-    if (!initialized){
-        Logger::Debug(__func__, "releasing");
-        return;
+    void pixel(uint32_t x, uint32_t y, uint32_t color)
+    {
+        RAIIMutex lock(mutex_backbufferAccess);
+        _pixel(x, y, color);
     }
-    memset(backbuffer, 0, (info->getPitch() * info->getHeight()));
-}
 
-void swap()
-{
-    Logger::Debug(__func__, "aquiring lock");
-    RAIIMutex lock(mutex_backbufferAccess);
-    Logger::Debug(__func__, "locked");
-
-    if (!initialized){
-        Logger::Debug(__func__, "releasing");
-        return;
+    static void _resetDoubleBuffer()
+    {
+        if (!initialized){
+            Logger::Debug(__func__, "releasing");
+            return;
+        }
+        memset(backbuffer, 0, (info->getPitch() * info->getHeight()));
     }
-    memcpy(info->getAddress(), backbuffer, (info->getPitch() * info->getHeight()));
+
+    void resetDoubleBuffer(){
+        Logger::Debug(__func__, "aquiring lock");
+        RAIIMutex lock(mutex_backbufferAccess);
+        Logger::Debug(__func__, "locked");
+
+        _resetDoubleBuffer();
+    }
+
+    static void _swap()
+    {
+        if (!initialized){
+            Logger::Debug(__func__, "releasing");
+            return;
+        }
+        memcpy(info->getAddress(), backbuffer, (info->getPitch() * info->getHeight()));
+    }
+
+    void swap()
+    {
+        Logger::Debug(__func__, "aquiring lock");
+        RAIIMutex lock(mutex_backbufferAccess);
+        Logger::Debug(__func__, "locked");
+
+        _swap();
+    }
+
+    /*
+        Shouldn't cause any more framebuffer issues.
+
+        - Ami, 26/05/26
+    */
+
+    void putrect(uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t color)
+    {
+        RAIIMutex lock(mutex_backbufferAccess);
+
+        // Ensure framebuffer information exists
+        if (!initialized)
+            return;
+        for (uint32_t curr_x = x; curr_x <= x + w; curr_x++) {
+            for (uint32_t curr_y = y; curr_y <= y + h; curr_y++) {
+                // Extremely slow but good for debugging
+                _pixel(curr_x, curr_y, color);
+            }
+        }
+        // Swap after doing a large operation
+        _swap();
+    }
 }
 
-} // !namespace graphics
+// !namespace graphics

--- a/Kernel/Devices/Graphics/graphics.cpp
+++ b/Kernel/Devices/Graphics/graphics.cpp
@@ -22,6 +22,7 @@
 #include <Library/stdio.hpp>
 #include <Library/string.hpp>
 #include <Logger.hpp>
+#include <Locking/RAII.hpp>
 
 namespace Graphics {
 
@@ -83,17 +84,37 @@ void putrect(uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t color)
     swap();
 }
 
+/*
+    I'd advise reading https://en.cppreference.com/cpp/thread/lock_guard for info about Mutex.
+    Saved me a lot of pain and taught it very easy.
+
+    - Ami, 25/05/26
+*/
+Mutex mutex_backbufferAccess("backbuffer");
+
 void resetDoubleBuffer()
 {
-    if (!initialized)
+    Logger::Debug(__func__, "aquiring lock");
+    RAIIMutex lock(mutex_backbufferAccess);
+    Logger::Debug(__func__, "locked");
+
+    if (!initialized){
+        Logger::Debug(__func__, "releasing");
         return;
+    }
     memset(backbuffer, 0, (info->getPitch() * info->getHeight()));
 }
 
 void swap()
 {
-    if (!initialized)
+    Logger::Debug(__func__, "aquiring lock");
+    RAIIMutex lock(mutex_backbufferAccess);
+    Logger::Debug(__func__, "locked");
+
+    if (!initialized){
+        Logger::Debug(__func__, "releasing");
         return;
+    }
     memcpy(info->getAddress(), backbuffer, (info->getPitch() * info->getHeight()));
 }
 

--- a/Kernel/Devices/Graphics/graphics.cpp
+++ b/Kernel/Devices/Graphics/graphics.cpp
@@ -28,120 +28,106 @@
 #include <Arch/i686/timer.hpp>
 
 namespace Graphics {
-    static Framebuffer* info = NULL;
-    static void* backbuffer = NULL;
-    static bool initialized = false;
+static Framebuffer* info = NULL;
+static void* backbuffer = NULL;
+static bool initialized = false;
 
-    void init(Framebuffer* fb)
-    {
-        // Get the framebuffer info
-        if (!(info = fb))
-            return;
-        // Ensure valid info is provided
-        if (!info->getAddress())
-            return;
-        // Map in the framebuffer
-        Logger::Debug(__func__, "==== MAP FRAMEBUFFER ====");
-        Memory::mapKernelRangeVirtual(Memory::Section(
-            (uintptr_t)info->getAddress(),
-            (info->getPitch() * info->getHeight())
-        ));
-        // Alloc the backbuffer
-        backbuffer = malloc(info->getPitch() * info->getHeight());
-        memcpy(backbuffer, info->getAddress(), info->getPitch() * info->getHeight());
-        initialized = true;
+void init(Framebuffer* fb)
+{
+    // Get the framebuffer info
+    if (!(info = fb))
+        return;
+    // Ensure valid info is provided
+    if (!info->getAddress())
+        return;
+    // Map in the framebuffer
+    Logger::Debug(__func__, "==== MAP FRAMEBUFFER ====");
+    Memory::mapKernelRangeVirtual(Memory::Section(
+        (uintptr_t)info->getAddress(),
+        (info->getPitch() * info->getHeight())
+    ));
+    // Alloc the backbuffer
+    Mutex mutex_backbufferAccess("backbuffer"); // <- And the mutex
+    backbuffer = malloc(info->getPitch() * info->getHeight());
+    memcpy(backbuffer, info->getAddress(), info->getPitch() * info->getHeight());
+    initialized = true;
+}
+
+static void _pixel(uint32_t x, uint32_t y, uint32_t color)
+{
+    // Ensure framebuffer information exists
+    if (!initialized)
+        return;
+    if ((x <= info->getWidth()) && (y <= info->getHeight())) {
+        // Special thanks to the SkiftOS contributors.
+        uint8_t* pixel = (uint8_t*)backbuffer + (y * info->getPitch()) + (x * info->getPixelWidth());
+        // Pixel information
+        pixel[0] = (color >> info->getBlueMaskShift()) & 0xff;  // B
+        pixel[1] = (color >> info->getGreenMaskShift()) & 0xff; // G
+        pixel[2] = (color >> info->getRedMaskShift()) & 0xff;   // R
+        // Additional pixel information
+        if (info->getPixelWidth() == 4)
+            pixel[3] = 0x00;
     }
+}
 
-    /*
-        I'd advise reading https://en.cppreference.com/cpp/thread/lock_guard for info about Mutex.
-        Saved me a lot of pain and taught it very easy.
+void pixel(uint32_t x, uint32_t y, uint32_t color)
+{
+    RAIIMutex lock(mutex_backbufferAccess);
+    _pixel(x, y, color);
+}
 
-        - Ami, 25/05/26
-    */
+static void _resetDoubleBuffer()
+{
+    if (!initialized){
+        Logger::Debug(__func__, "releasing");
+        return;
+    }
+    memset(backbuffer, 0, (info->getPitch() * info->getHeight()));
+}
 
-    Mutex mutex_backbufferAccess("backbuffer");
+void resetDoubleBuffer(){
+    Logger::Debug(__func__, "aquiring lock");
+    RAIIMutex lock(mutex_backbufferAccess);
+    Logger::Debug(__func__, "locked");
 
-    static void _pixel(uint32_t x, uint32_t y, uint32_t color)
-    {
-        // Ensure framebuffer information exists
-        if (!initialized)
-            return;
-        if ((x <= info->getWidth()) && (y <= info->getHeight())) {
-            // Special thanks to the SkiftOS contributors.
-            uint8_t* pixel = (uint8_t*)backbuffer + (y * info->getPitch()) + (x * info->getPixelWidth());
-            // Pixel information
-            pixel[0] = (color >> info->getBlueMaskShift()) & 0xff;  // B
-            pixel[1] = (color >> info->getGreenMaskShift()) & 0xff; // G
-            pixel[2] = (color >> info->getRedMaskShift()) & 0xff;   // R
-            // Additional pixel information
-            if (info->getPixelWidth() == 4)
-                pixel[3] = 0x00;
+    _resetDoubleBuffer();
+}
+
+static void _swap()
+{
+    if (!initialized){
+        Logger::Debug(__func__, "releasing");
+        return;
+    }
+    memcpy(info->getAddress(), backbuffer, (info->getPitch() * info->getHeight()));
+}
+
+void swap()
+{
+    Logger::Debug(__func__, "aquiring lock");
+    RAIIMutex lock(mutex_backbufferAccess);
+    Logger::Debug(__func__, "locked");
+
+    _swap();
+}
+
+void putrect(uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t color)
+{
+    RAIIMutex lock(mutex_backbufferAccess);
+
+    // Ensure framebuffer information exists
+    if (!initialized)
+        return;
+    for (uint32_t curr_x = x; curr_x <= x + w; curr_x++) {
+        for (uint32_t curr_y = y; curr_y <= y + h; curr_y++) {
+            // Extremely slow but good for debugging
+            _pixel(curr_x, curr_y, color);
         }
     }
-
-    void pixel(uint32_t x, uint32_t y, uint32_t color)
-    {
-        RAIIMutex lock(mutex_backbufferAccess);
-        _pixel(x, y, color);
-    }
-
-    static void _resetDoubleBuffer()
-    {
-        if (!initialized){
-            Logger::Debug(__func__, "releasing");
-            return;
-        }
-        memset(backbuffer, 0, (info->getPitch() * info->getHeight()));
-    }
-
-    void resetDoubleBuffer(){
-        Logger::Debug(__func__, "aquiring lock");
-        RAIIMutex lock(mutex_backbufferAccess);
-        Logger::Debug(__func__, "locked");
-
-        _resetDoubleBuffer();
-    }
-
-    static void _swap()
-    {
-        if (!initialized){
-            Logger::Debug(__func__, "releasing");
-            return;
-        }
-        memcpy(info->getAddress(), backbuffer, (info->getPitch() * info->getHeight()));
-    }
-
-    void swap()
-    {
-        Logger::Debug(__func__, "aquiring lock");
-        RAIIMutex lock(mutex_backbufferAccess);
-        Logger::Debug(__func__, "locked");
-
-        _swap();
-    }
-
-    /*
-        Shouldn't cause any more framebuffer issues.
-
-        - Ami, 26/05/26
-    */
-
-    void putrect(uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t color)
-    {
-        RAIIMutex lock(mutex_backbufferAccess);
-
-        // Ensure framebuffer information exists
-        if (!initialized)
-            return;
-        for (uint32_t curr_x = x; curr_x <= x + w; curr_x++) {
-            for (uint32_t curr_y = y; curr_y <= y + h; curr_y++) {
-                // Extremely slow but good for debugging
-                _pixel(curr_x, curr_y, color);
-            }
-        }
-        // Swap after doing a large operation
-        _swap();
-    }
+    // Swap after doing a large operation
+    _swap();
+}
 }
 
 // !namespace graphics

--- a/Kernel/Devices/Graphics/graphics.cpp
+++ b/Kernel/Devices/Graphics/graphics.cpp
@@ -2,6 +2,7 @@
  * @file graphics.cpp
  * @author Keeton Feavel (keetonfeavel@cedarville.edu)
  * @author Michel (JMallone) Gomes (michels@utfpr.edu.br)
+ * @author Amilie Baker (amiliefn@gmail.com)
  * @brief Graphics management and control
  * @version 0.2
  * @date 2021-07-24
@@ -11,6 +12,7 @@
  * References:
  *     https://wiki.osdev.org/Double_Buffering
  *     https://github.com/skiftOS/skift/blob/main/kernel/system/Graphics/Graphics.cpp
+ *     https://en.cppreference.com/cpp/thread/lock_guard
  *
  */
 #include <Devices/Graphics/graphics.hpp>
@@ -23,6 +25,7 @@
 #include <Library/string.hpp>
 #include <Logger.hpp>
 #include <Locking/RAII.hpp>
+#include <Arch/i686/timer.hpp>
 
 namespace Graphics {
 
@@ -47,7 +50,6 @@ void init(Framebuffer* fb)
     // Alloc the backbuffer
     backbuffer = malloc(info->getPitch() * info->getHeight());
     memcpy(backbuffer, info->getAddress(), info->getPitch() * info->getHeight());
-
     initialized = true;
 }
 

--- a/Kernel/Entry.cpp
+++ b/Kernel/Entry.cpp
@@ -30,6 +30,7 @@
 // Apps
 #include <Applications/primes.hpp>
 #include <Applications/spinner.hpp>
+#include <Applications/fbtest.hpp>
 // Meta
 #include <stdint.h>
 
@@ -106,10 +107,11 @@ void kernelEntry(void* info, uint32_t magic)
         time.getMinutes());
     Logger::Info(__func__, "%s\n%s\n", Arch::CPU::vendor(), Arch::CPU::model());
 
-    struct task compute, status, spinner;
+    struct task compute, status, spinner, fbtest;
     tasks_new(Apps::find_primes, &compute, TASK_READY, "prime_compute");
     tasks_new(Apps::show_primes, &status, TASK_READY, "prime_display");
     tasks_new(Apps::spinner, &spinner, TASK_READY, "spinner");
+    tasks_new(Apps::fbtest, &fbtest, TASK_READY, "fbtest");
     // Now that we're done make a joyful noise
     bootTone();
 


### PR DESCRIPTION
Now improved locking on the FBMutex as seen in issue #284 in order to ensure that frame buffer works better. There are now test programs in /Applications/fbtest.cpp/hpp.

To ensure that this works, you can keep these enabled. Disable them via Entry.cpp and removing any "fbtest" references.

```UG  ] resetDoubleBuffer      aquiring lock
[DEBUG  ] tasks_block_current    fbtest is BLOCKED
[DEBUG  ] _wakeup                fbtest is READY
[DEBUG  ] resetDoubleBuffer      locked
[DEBUG  ] tasks_block_current    spinner is BLOCKED
[DEBUG  ] _wakeup                spinner is READY
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] resetDoubleBuffer      aquiring lock
[DEBUG  ] tasks_block_current    fbtest is BLOCKED
[DEBUG  ] _wakeup                fbtest is READY
[DEBUG  ] resetDoubleBuffer      locked
[DEBUG  ] tasks_block_current    spinner is BLOCKED
[DEBUG  ] _wakeup                spinner is READY
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[VERBOSE] _on_timer              timer: waking sleeping task
[DEBUG  ] _wakeup                prime_display is READY
[DEBUG  ] tasks_block_current    prime_display is BLOCKED
[DEBUG  ] _wakeup                prime_display is READY
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] tasks_block_current    spinner is BLOCKED
[DEBUG  ] _wakeup                spinner is READY
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] resetDoubleBuffer      aquiring lock
[DEBUG  ] tasks_block_current    fbtest is BLOCKED
[DEBUG  ] _wakeup                fbtest is READY
[DEBUG  ] resetDoubleBuffer      locked
[DEBUG  ] tasks_block_current    spinner is BLOCKED
[DEBUG  ] _wakeup                spinner is READY
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] resetDoubleBuffer      aquiring lock
[DEBUG  ] tasks_block_current    fbtest is BLOCKED
[DEBUG  ] _wakeup                fbtest is READY
[DEBUG  ] resetDoubleBuffer      locked
[DEBUG  ] tasks_block_current    spinner is BLOCKED
[DEBUG  ] _wakeup                spinner is READY
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] resetDoubleBuffer      aquiring lock
[DEBUG  ] tasks_block_current    fbtest is BLOCKED
[DEBUG  ] _wakeup                fbtest is READY
[DEBUG  ] resetDoubleBuffer      locked
[DEBUG  ] tasks_block_current    spinner is BLOCKED
[DEBUG  ] _wakeup                spinner is READY
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] tasks_block_current    prime_display is BLOCKED
[DEBUG  ] _wakeup                prime_display is READY
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] tasks_block_current    spinner is BLOCKED
[DEBUG  ] _wakeup                spinner is READY
[DEBUG  ] resetDoubleBuffer      aquiring lock
[DEBUG  ] resetDoubleBuffer      locked
[DEBUG  ] tasks_block_current    spinner is BLOCKED
[DEBUG  ] tasks_exit             task "prime_display" (0xc011eab0) exiting
[DEBUG  ] tasks_block_current    prime_display is STOPPED
[DEBUG  ] tasks_unblock          [cleaner] is READY
[DEBUG  ] _cleaner_task_impl     cleaning up task prime_display (0xc011eab0)
[DEBUG  ] tasks_block_current    [cleaner] is PAUSED
[DEBUG  ] _wakeup                spinner is READY
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] resetDoubleBuffer      aquiring lock
[DEBUG  ] tasks_block_current    fbtest is BLOCKED
[DEBUG  ] _wakeup                fbtest is READY
[DEBUG  ] resetDoubleBuffer      locked
[DEBUG  ] tasks_block_current    spinner is BLOCKED
[DEBUG  ] _wakeup                spinner is READY
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] swap                   aquiring lock
[DEBUG  ] swap                   locked
[DEBUG  ] resetDoubleBuffer      aquiring lock
[DEBUG  ] tasks_block_current    fbtest is BLOCKED
[DEBUG  ] _wakeup                fbtest is READY
[DEBUG  ] resetDoubleBuffer      locked
[DEBUG  ] tasks_block_current    spinner is BLOCKED```