### PR TITLE
[ROADMAP] IPC Completion (Pipes & Messaging)

### DIFF
--- a/Kernel/Applications/fbtest.cpp
+++ b/Kernel/Applications/fbtest.cpp
@@ -1,6 +1,6 @@
 /**
- * @file entry.cpp
- * @author Amilie Baker(amiliefn@gmail.com)
+ * @file fbtest.cpp
+ * @author Amilie Baker (amiliefn@gmail.com)
  * @brief Simple framebuffer tester.
  * @version 0.2
  * @date 2026-05-25
@@ -15,11 +15,11 @@
 
 namespace Apps {
 
-void fbtest()
-{
-    while (true) {
-        sleep(100);
-        Graphics::resetDoubleBuffer();
+    void fbtest()
+    {
+        while (true) {
+            sleep(100);
+            Graphics::resetDoubleBuffer();
+        }
     }
-}
 }

--- a/Kernel/Applications/fbtest.cpp
+++ b/Kernel/Applications/fbtest.cpp
@@ -1,0 +1,25 @@
+/**
+ * @file entry.cpp
+ * @author Amilie Baker(amiliefn@gmail.com)
+ * @brief Simple framebuffer tester.
+ * @version 0.2
+ * @date 2026-05-25
+ *
+ * @copyright Copyright the Xyris Contributors (c) 2026
+ *
+ */
+
+#include <Devices/Graphics/graphics.hpp>
+#include <Arch/i686/timer.hpp>
+#include <Applications/fbtest.hpp>
+
+namespace Apps {
+
+void fbtest()
+{
+    while (true) {
+        sleep(100);
+        Graphics::resetDoubleBuffer();
+    }
+}
+}

--- a/Kernel/Applications/fbtest.hpp
+++ b/Kernel/Applications/fbtest.hpp
@@ -1,0 +1,21 @@
+/**
+ * @file entry.cpp
+ * @author Amilie Baker(amiliefn@gmail.com)
+ * @brief Simple framebuffer tester.
+ * @version 0.3
+ * @date 2026-05-25
+ *
+ * @copyright Copyright the Xyris Contributors (c) 2026
+ *
+ */
+
+#pragma once
+namespace Apps {
+
+/**
+ * @brief Test framebuffer
+ *
+ */
+void fbtest();
+
+}

--- a/Kernel/Applications/piper.cpp
+++ b/Kernel/Applications/piper.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <IPC/pipes.hpp>
+#include <IPC/messages.hpp>
 #include <Devices/Graphics/console.hpp>
 #include <Applications/piper.hpp>
 
@@ -42,5 +43,32 @@ namespace Apps {
                 
         close_pipe(p, true);
         close_pipe(p, false);
+
+        msg_queue_t* q = create_msg();
+
+        msg_t send;
+        send.sender_id = 1;
+        send.type_id = 42;
+        send.payload[0] = 'H';
+        send.payload[1] = 'i';
+
+        write_msg(q, &send);
+        msg_t recv;
+        read_msg(q, &recv);
+
+        bool msg_passed = true;
+        if (recv.sender_id != send.sender_id) msg_passed = false;
+        if (recv.type_id != send.type_id) msg_passed = false;
+        if (recv.payload[0] != send.payload[0]) msg_passed = false;
+        if (recv.payload[1] != send.payload[1]) msg_passed = false;
+
+        if (msg_passed) {
+            Console::printf("Passed Message Test!\n");
+        } else {
+            Console::printf("Failed Message Test!\n");
+        }
+
+        close_msg(q, true);
+        close_msg(q, false);
     }
 }

--- a/Kernel/Applications/piper.cpp
+++ b/Kernel/Applications/piper.cpp
@@ -1,0 +1,46 @@
+/**
+ * @file piper.cpp
+ * @author Amilie Baker (amiliefn@gmail.com)
+ * @brief A piping test / solution to ensure IPC works.
+ * @version 0.2
+ * @date 2026-05-26
+ *
+ * @copyright Copyright the Xyris Contributors (c) 2026
+ *
+ */
+
+#include <IPC/pipes.hpp>
+#include <Devices/Graphics/console.hpp>
+#include <Applications/piper.hpp>
+
+namespace Apps {
+
+    void piper()
+    {
+        pipe_t* p = create_pipe();
+        
+        const char* msg = "Hello pipes!";
+        size_t len = 12;
+        
+        write_pipe(p, msg, len);
+        
+        char result[12];
+        read_pipe(p, result, len);
+        
+        bool passed = true;
+        for (size_t i = 0; i < len; i++){
+            if (result[i] != msg[i]){
+                passed = false;
+            }
+        }
+
+        if(passed){
+            Console::printf("Passed Pipe Test!\n");
+        }else{
+            Console::printf("Failed Pipe Test!\n");
+        }
+                
+        close_pipe(p, true);
+        close_pipe(p, false);
+    }
+}

--- a/Kernel/Applications/piper.hpp
+++ b/Kernel/Applications/piper.hpp
@@ -1,9 +1,9 @@
 /**
- * @file fbtest.hpp
+ * @file piper.hpp
  * @author Amilie Baker (amiliefn@gmail.com)
- * @brief Simple framebuffer tester.
- * @version 0.3
- * @date 2026-05-25
+ * @brief A piping test / solution to ensure IPC works.
+ * @version 0.2
+ * @date 2026-05-26
  *
  * @copyright Copyright the Xyris Contributors (c) 2026
  *
@@ -13,9 +13,9 @@
 namespace Apps {
 
 /**
- * @brief Test framebuffer
+ * @brief Test Piping solution
  *
  */
-void fbtest();
+void piper();
 
 }

--- a/Kernel/Devices/Graphics/graphics.cpp
+++ b/Kernel/Devices/Graphics/graphics.cpp
@@ -28,96 +28,120 @@
 #include <Arch/i686/timer.hpp>
 
 namespace Graphics {
+    static Framebuffer* info = NULL;
+    static void* backbuffer = NULL;
+    static bool initialized = false;
 
-static Framebuffer* info = NULL;
-static void* backbuffer = NULL;
-static bool initialized = false;
-
-void init(Framebuffer* fb)
-{
-    // Get the framebuffer info
-    if (!(info = fb))
-        return;
-    // Ensure valid info is provided
-    if (!info->getAddress())
-        return;
-    // Map in the framebuffer
-    Logger::Debug(__func__, "==== MAP FRAMEBUFFER ====");
-    Memory::mapKernelRangeVirtual(Memory::Section(
-        (uintptr_t)info->getAddress(),
-        (info->getPitch() * info->getHeight())
-    ));
-    // Alloc the backbuffer
-    backbuffer = malloc(info->getPitch() * info->getHeight());
-    memcpy(backbuffer, info->getAddress(), info->getPitch() * info->getHeight());
-    initialized = true;
-}
-
-void pixel(uint32_t x, uint32_t y, uint32_t color)
-{
-    // Ensure framebuffer information exists
-    if (!initialized)
-        return;
-    if ((x <= info->getWidth()) && (y <= info->getHeight())) {
-        // Special thanks to the SkiftOS contributors.
-        uint8_t* pixel = (uint8_t*)backbuffer + (y * info->getPitch()) + (x * info->getPixelWidth());
-        // Pixel information
-        pixel[0] = (color >> info->getBlueMaskShift()) & 0xff;  // B
-        pixel[1] = (color >> info->getGreenMaskShift()) & 0xff; // G
-        pixel[2] = (color >> info->getRedMaskShift()) & 0xff;   // R
-        // Additional pixel information
-        if (info->getPixelWidth() == 4)
-            pixel[3] = 0x00;
+    void init(Framebuffer* fb)
+    {
+        // Get the framebuffer info
+        if (!(info = fb))
+            return;
+        // Ensure valid info is provided
+        if (!info->getAddress())
+            return;
+        // Map in the framebuffer
+        Logger::Debug(__func__, "==== MAP FRAMEBUFFER ====");
+        Memory::mapKernelRangeVirtual(Memory::Section(
+            (uintptr_t)info->getAddress(),
+            (info->getPitch() * info->getHeight())
+        ));
+        // Alloc the backbuffer
+        backbuffer = malloc(info->getPitch() * info->getHeight());
+        memcpy(backbuffer, info->getAddress(), info->getPitch() * info->getHeight());
+        initialized = true;
     }
-}
 
-void putrect(uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t color)
-{
-    // Ensure framebuffer information exists
-    if (!initialized)
-        return;
-    for (uint32_t curr_x = x; curr_x <= x + w; curr_x++) {
-        for (uint32_t curr_y = y; curr_y <= y + h; curr_y++) {
-            // Extremely slow but good for debugging
-            pixel(curr_x, curr_y, color);
+    /*
+        I'd advise reading https://en.cppreference.com/cpp/thread/lock_guard for info about Mutex.
+        Saved me a lot of pain and taught it very easy.
+
+        - Ami, 25/05/26
+    */
+
+    Mutex mutex_backbufferAccess("backbuffer");
+
+    static void _pixel(uint32_t x, uint32_t y, uint32_t color)
+    {
+        // Ensure framebuffer information exists
+        if (!initialized)
+            return;
+        if ((x <= info->getWidth()) && (y <= info->getHeight())) {
+            // Special thanks to the SkiftOS contributors.
+            uint8_t* pixel = (uint8_t*)backbuffer + (y * info->getPitch()) + (x * info->getPixelWidth());
+            // Pixel information
+            pixel[0] = (color >> info->getBlueMaskShift()) & 0xff;  // B
+            pixel[1] = (color >> info->getGreenMaskShift()) & 0xff; // G
+            pixel[2] = (color >> info->getRedMaskShift()) & 0xff;   // R
+            // Additional pixel information
+            if (info->getPixelWidth() == 4)
+                pixel[3] = 0x00;
         }
     }
-    // Swap after doing a large operation
-    swap();
-}
 
-/*
-    I'd advise reading https://en.cppreference.com/cpp/thread/lock_guard for info about Mutex.
-    Saved me a lot of pain and taught it very easy.
-
-    - Ami, 25/05/26
-*/
-Mutex mutex_backbufferAccess("backbuffer");
-
-void resetDoubleBuffer()
-{
-    Logger::Debug(__func__, "aquiring lock");
-    RAIIMutex lock(mutex_backbufferAccess);
-    Logger::Debug(__func__, "locked");
-
-    if (!initialized){
-        Logger::Debug(__func__, "releasing");
-        return;
+    void pixel(uint32_t x, uint32_t y, uint32_t color)
+    {
+        RAIIMutex lock(mutex_backbufferAccess);
+        _pixel(x, y, color);
     }
-    memset(backbuffer, 0, (info->getPitch() * info->getHeight()));
-}
 
-void swap()
-{
-    Logger::Debug(__func__, "aquiring lock");
-    RAIIMutex lock(mutex_backbufferAccess);
-    Logger::Debug(__func__, "locked");
-
-    if (!initialized){
-        Logger::Debug(__func__, "releasing");
-        return;
+    static void _resetDoubleBuffer()
+    {
+        if (!initialized){
+            Logger::Debug(__func__, "releasing");
+            return;
+        }
+        memset(backbuffer, 0, (info->getPitch() * info->getHeight()));
     }
-    memcpy(info->getAddress(), backbuffer, (info->getPitch() * info->getHeight()));
+
+    void resetDoubleBuffer(){
+        Logger::Debug(__func__, "aquiring lock");
+        RAIIMutex lock(mutex_backbufferAccess);
+        Logger::Debug(__func__, "locked");
+
+        _resetDoubleBuffer();
+    }
+
+    static void _swap()
+    {
+        if (!initialized){
+            Logger::Debug(__func__, "releasing");
+            return;
+        }
+        memcpy(info->getAddress(), backbuffer, (info->getPitch() * info->getHeight()));
+    }
+
+    void swap()
+    {
+        Logger::Debug(__func__, "aquiring lock");
+        RAIIMutex lock(mutex_backbufferAccess);
+        Logger::Debug(__func__, "locked");
+
+        _swap();
+    }
+
+    /*
+        Shouldn't cause any more framebuffer issues.
+
+        - Ami, 26/05/26
+    */
+
+    void putrect(uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t color)
+    {
+        RAIIMutex lock(mutex_backbufferAccess);
+
+        // Ensure framebuffer information exists
+        if (!initialized)
+            return;
+        for (uint32_t curr_x = x; curr_x <= x + w; curr_x++) {
+            for (uint32_t curr_y = y; curr_y <= y + h; curr_y++) {
+                // Extremely slow but good for debugging
+                _pixel(curr_x, curr_y, color);
+            }
+        }
+        // Swap after doing a large operation
+        _swap();
+    }
 }
 
-} // !namespace graphics
+// !namespace graphics

--- a/Kernel/Devices/Graphics/graphics.cpp
+++ b/Kernel/Devices/Graphics/graphics.cpp
@@ -22,6 +22,7 @@
 #include <Library/stdio.hpp>
 #include <Library/string.hpp>
 #include <Logger.hpp>
+#include <Locking/RAII.hpp>
 
 namespace Graphics {
 
@@ -83,17 +84,37 @@ void putrect(uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t color)
     swap();
 }
 
+/*
+    I'd advise reading https://en.cppreference.com/cpp/thread/lock_guard for info about Mutex.
+    Saved me a lot of pain and taught it very easy.
+
+    - Ami, 25/05/26
+*/
+Mutex mutex_backbufferAccess("backbuffer");
+
 void resetDoubleBuffer()
 {
-    if (!initialized)
+    Logger::Debug(__func__, "aquiring lock");
+    RAIIMutex lock(mutex_backbufferAccess);
+    Logger::Debug(__func__, "locked");
+
+    if (!initialized){
+        Logger::Debug(__func__, "releasing");
         return;
+    }
     memset(backbuffer, 0, (info->getPitch() * info->getHeight()));
 }
 
 void swap()
 {
-    if (!initialized)
+    Logger::Debug(__func__, "aquiring lock");
+    RAIIMutex lock(mutex_backbufferAccess);
+    Logger::Debug(__func__, "locked");
+
+    if (!initialized){
+        Logger::Debug(__func__, "releasing");
         return;
+    }
     memcpy(info->getAddress(), backbuffer, (info->getPitch() * info->getHeight()));
 }
 

--- a/Kernel/Devices/Graphics/graphics.cpp
+++ b/Kernel/Devices/Graphics/graphics.cpp
@@ -2,6 +2,7 @@
  * @file graphics.cpp
  * @author Keeton Feavel (keetonfeavel@cedarville.edu)
  * @author Michel (JMallone) Gomes (michels@utfpr.edu.br)
+ * @author Amilie Baker (amiliefn@gmail.com)
  * @brief Graphics management and control
  * @version 0.2
  * @date 2021-07-24
@@ -11,6 +12,7 @@
  * References:
  *     https://wiki.osdev.org/Double_Buffering
  *     https://github.com/skiftOS/skift/blob/main/kernel/system/Graphics/Graphics.cpp
+ *     https://en.cppreference.com/cpp/thread/lock_guard
  *
  */
 #include <Devices/Graphics/graphics.hpp>
@@ -23,6 +25,7 @@
 #include <Library/string.hpp>
 #include <Logger.hpp>
 #include <Locking/RAII.hpp>
+#include <Arch/i686/timer.hpp>
 
 namespace Graphics {
 
@@ -47,7 +50,6 @@ void init(Framebuffer* fb)
     // Alloc the backbuffer
     backbuffer = malloc(info->getPitch() * info->getHeight());
     memcpy(backbuffer, info->getAddress(), info->getPitch() * info->getHeight());
-
     initialized = true;
 }
 

--- a/Kernel/Entry.cpp
+++ b/Kernel/Entry.cpp
@@ -31,6 +31,7 @@
 #include <Applications/primes.hpp>
 #include <Applications/spinner.hpp>
 #include <Applications/fbtest.hpp>
+#include <Applications/piper.hpp>
 // Meta
 #include <stdint.h>
 
@@ -107,11 +108,21 @@ void kernelEntry(void* info, uint32_t magic)
         time.getMinutes());
     Logger::Info(__func__, "%s\n%s\n", Arch::CPU::vendor(), Arch::CPU::model());
 
-    struct task compute, status, spinner, fbtest;
+    /*
+        LIST OF AVAILABLE TASKS:
+        - prime_compute
+        - prime_display
+        - spinner
+        - fbtest
+        - piper
+    */
+
+    struct task compute, status, spinner, piper; // add fbtest back to list when needed.
     tasks_new(Apps::find_primes, &compute, TASK_READY, "prime_compute");
     tasks_new(Apps::show_primes, &status, TASK_READY, "prime_display");
     tasks_new(Apps::spinner, &spinner, TASK_READY, "spinner");
-    tasks_new(Apps::fbtest, &fbtest, TASK_READY, "fbtest");
+    // tasks_new(Apps::fbtest, &fbtest, TASK_READY, "fbtest");
+    tasks_new(Apps::piper, &piper, TASK_READY, "piper");
     // Now that we're done make a joyful noise
     bootTone();
 

--- a/Kernel/Entry.cpp
+++ b/Kernel/Entry.cpp
@@ -30,6 +30,7 @@
 // Apps
 #include <Applications/primes.hpp>
 #include <Applications/spinner.hpp>
+#include <Applications/fbtest.hpp>
 // Meta
 #include <stdint.h>
 
@@ -106,10 +107,11 @@ void kernelEntry(void* info, uint32_t magic)
         time.getMinutes());
     Logger::Info(__func__, "%s\n%s\n", Arch::CPU::vendor(), Arch::CPU::model());
 
-    struct task compute, status, spinner;
+    struct task compute, status, spinner, fbtest;
     tasks_new(Apps::find_primes, &compute, TASK_READY, "prime_compute");
     tasks_new(Apps::show_primes, &status, TASK_READY, "prime_display");
     tasks_new(Apps::spinner, &spinner, TASK_READY, "spinner");
+    tasks_new(Apps::fbtest, &fbtest, TASK_READY, "fbtest");
     // Now that we're done make a joyful noise
     bootTone();
 

--- a/Kernel/IPC/messages.cpp
+++ b/Kernel/IPC/messages.cpp
@@ -1,0 +1,90 @@
+/**
+ * @file messages.cpp
+ * @author Amilie Baker (amiliefn@gmail.com)
+ * @brief Messaging infrastructure for IPC.
+ * @version 0.1
+ * @date 2026-05-27 
+ *
+ * @copyright Copyright the Xyris Contributors (c) 2026
+ * @ref https://wiki.osdev.org/Message_Passing
+ * @ref https://stackoverflow.com/questions/25074741/how-do-i-store-and-get-a-queue-of-structure
+ *
+ */
+
+#include <IPC/messages.hpp>
+#include <Locking/Semaphore.hpp>
+#include <Locking/Mutex.hpp>
+#include <Locking/RAII.hpp>
+
+/*
+    This code is BASICALLY the same as pipes.ccp - I'm using the same jank workarounds.
+    Good luck percieving it.
+    - Ami, 27/05/26
+*/
+Mutex mutex_msg("msg");
+inline void* operator new(size_t, void* ptr) { return ptr; }
+
+msg_queue_t* create_msg(){
+    void* mem = operator new(sizeof(msg_queue_t));
+    if(mem != NULL){
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-possible-null-argument"
+        return new (mem) msg_queue_t;
+#pragma GCC diagnostic pop
+    }
+    return 0;
+}
+
+/*
+    Main change here is changing of uint to just *msg, and also the reduction in buffer count to 64.
+    We also do not iterate thru every byte now.
+    - Ami, 27/05/26
+*/
+int write_msg(msg_queue_t* queue, msg_t* msg){  
+    queue->space_available.wait();
+    if(queue->readers == 0){
+        return -1;
+    }else{
+        RAIIMutex lock(mutex_msg);
+        queue->buffer[queue->write_pos] = *msg;
+
+        queue->write_pos = (queue->write_pos + 1) % 64;
+        queue->count++;
+        queue->data_available.post();
+    }
+    return 1;
+}
+
+int read_msg(msg_queue_t* queue, msg_t* msg){
+    queue->data_available.wait();
+
+    if(queue->writers == 0 && queue->count==0){
+        return 0;
+    }else{
+        RAIIMutex lock(mutex_msg);
+        *msg = queue->buffer[queue->read_pos];
+
+        queue->read_pos = (queue->read_pos + 1) % 64;
+        queue->count--;
+    }
+    queue->space_available.post();
+    return 1;
+}
+
+void close_msg(msg_queue_t* queue, bool is_write_end){
+    if(is_write_end == 1){
+        queue->writers--;
+        if(queue->writers == 0){
+            queue->data_available.post();
+        }
+    }else{
+        queue->readers--;
+        if(queue->readers == 0){
+            queue->space_available.post();
+        }
+    }
+
+    if(queue->readers == 0 && queue->writers == 0){
+        delete queue;
+    }
+}

--- a/Kernel/IPC/messages.hpp
+++ b/Kernel/IPC/messages.hpp
@@ -1,0 +1,54 @@
+/**
+ * @file messages.hpp
+ * @author Amilie Baker (amiliefn@gmail.com)
+ * @brief Messaging infrastructure for IPC.
+ * @version 0.1
+ * @date 2026-05-27 
+ *
+ * @copyright Copyright the Xyris Contributors (c) 2026
+ * @ref https://wiki.osdev.org/Message_Passing
+ * @ref https://stackoverflow.com/questions/25074741/how-do-i-store-and-get-a-queue-of-structure
+ *
+ */
+#include <Locking/Semaphore.hpp>
+#include <Locking/Mutex.hpp>
+#include <Locking/RAII.hpp>
+
+struct msg_t{
+    uint8_t sender_id;
+    uint8_t type_id;
+    uint8_t payload[64];
+
+    msg_t()
+        : sender_id(0)
+        , type_id(0)
+        , payload{}
+    {}
+};
+
+struct msg_queue_t{
+    msg_t buffer[64];
+    size_t read_pos;
+    size_t write_pos;
+    size_t count;
+    Semaphore data_available;
+    Semaphore space_available;
+    Mutex lock;
+    int readers;
+    int writers;
+
+    msg_queue_t()
+    : read_pos(0)
+    , write_pos(0)
+    , count(0)
+    , data_available(0, false, "msg_data")
+    , space_available(64, false, "msg_space")
+    , readers(1)
+    , writers(1)
+{}
+};
+
+msg_queue_t* create_msg();
+int write_msg(msg_queue_t* queue, msg_t* msg);
+int read_msg(msg_queue_t* queue, msg_t* msg);
+void close_msg(msg_queue_t* queue, bool is_write_end);

--- a/Kernel/IPC/pipes.cpp
+++ b/Kernel/IPC/pipes.cpp
@@ -1,0 +1,104 @@
+/**
+ * @file pipes.cpp
+ * @author Amilie Baker (amiliefn@gmail.com)
+ * @brief Piping infrastructure for IPC.
+ * @version 0.1
+ * @date 2026-05-26
+ *
+ * @copyright Copyright the Xyris Contributors (c) 2026
+ *
+ */
+
+#include <IPC/pipes.hpp>
+#include <Locking/Semaphore.hpp>
+#include <Locking/Mutex.hpp>
+#include <Locking/RAII.hpp>
+
+/* 
+    For Mutex locking in write_pipe.
+*/
+Mutex mutex_pipe("pipe");
+inline void* operator new(size_t, void* ptr) { return ptr; }
+
+/*
+    This shit about to be MESSY but it's gotta be done.
+*/
+pipe_t* create_pipe(){
+    void* mem = operator new(sizeof(pipe_t));
+    if(mem != NULL){
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-possible-null-argument"
+        return new (mem) pipe_t;
+#pragma GCC diagnostic pop
+    }
+    return 0;
+}
+
+/*
+    Writing info to the pipes, ensuring that different processes cannot conflict.
+*/
+int write_pipe(pipe_t* pipe, const void* data, size_t size){
+    for (size_t i = 0; i < size; i++){
+        pipe->space_available.wait();
+        if(pipe->readers == 0){
+            return -1;
+        }else{
+            RAIIMutex lock(mutex_pipe);
+
+            /*
+                Casting so we can actually iterate on it.
+                (This weather is horrible. FML.)
+
+                - Ami, 26/05/26
+            */
+            pipe->buffer[pipe->write_pos] = ((uint8_t*)data)[i];
+
+            pipe->write_pos = (pipe->write_pos + 1) % 4096;
+            pipe->count++;
+        }
+            pipe->data_available.post();
+    }
+    return size;
+}
+
+/*
+    Literally just an inversion of write_pipe.
+*/
+int read_pipe(pipe_t *pipe, void* data, size_t size){
+    for (size_t i = 0; i < size; i++){
+        pipe->space_available.wait();
+
+        if(pipe->writers == 0 && pipe->count==0){
+            return 0;
+        }else{
+            RAIIMutex lock(mutex_pipe);
+            ((uint8_t*)data)[i] = pipe->buffer[pipe->read_pos];
+
+            pipe->read_pos = (pipe->read_pos + 1) % 4096;
+            pipe->count--;
+        }
+            pipe->space_available.post();
+    }
+    return size;
+}
+
+/*
+    Checks for complete freeing and does cleanup.
+*/
+void close_pipe(pipe_t *pipe, bool is_write_end){
+    if(is_write_end == 1){
+        pipe->writers--;
+        if(pipe->writers == 0){
+            pipe->data_available.post();
+        }
+    }else{
+        pipe->readers--;
+        if(pipe->readers == 0){
+            pipe->space_available.post();
+        }
+    }
+
+    if(pipe->readers == 0 && pipe->writers == 0){
+        delete pipe;
+    }
+}

--- a/Kernel/IPC/pipes.cpp
+++ b/Kernel/IPC/pipes.cpp
@@ -6,6 +6,10 @@
  * @date 2026-05-26
  *
  * @copyright Copyright the Xyris Contributors (c) 2026
+ * @ref https://github.com/mit-pdos/xv6-public/blob/master/pipe.c
+ * @ref https://www.usna.edu/Users/cs/wcbrown/courses/IC221/classes/L13/Class.html
+ * @ref https://wiki.osdev.org/Message_Passing
+ * @ref https://github.com/mit-pdos/xv6-public/blob/master/pipe.c
  *
  */
 

--- a/Kernel/IPC/pipes.cpp
+++ b/Kernel/IPC/pipes.cpp
@@ -22,6 +22,7 @@ inline void* operator new(size_t, void* ptr) { return ptr; }
 
 /*
     This shit about to be MESSY but it's gotta be done.
+    Blocked the compiler warnings as it wouldn't compile. MANUALLY CONFIRMED IT IS SAFE THOUGH.
 */
 pipe_t* create_pipe(){
     void* mem = operator new(sizeof(pipe_t));

--- a/Kernel/IPC/pipes.hpp
+++ b/Kernel/IPC/pipes.hpp
@@ -1,0 +1,43 @@
+/**
+ * @file pipes.hpp
+ * @author Amilie Baker (amiliefn@gmail.com)
+ * @brief Piping infrastructure for IPC.
+ * @version 0.1
+ * @date 2026-05-26
+ *
+ * @copyright Copyright the Xyris Contributors (c) 2026
+ *
+ */
+
+#include <Locking/Semaphore.hpp>
+#include <Locking/Mutex.hpp>
+
+/*
+    Semaphore want's values like this yah.
+*/
+struct pipe_t{
+    uint8_t buffer[4096];
+    size_t read_pos;
+    size_t write_pos;
+    size_t count;
+    Semaphore data_available;
+    Semaphore space_available;
+    Mutex lock;
+    int readers;
+    int writers;
+
+    pipe_t()
+        : read_pos(0)
+        , write_pos(0)
+        , count(0)
+        , data_available(0, false, "pipe_data")
+        , space_available(4096, false, "pipe_space")
+        , readers(1)
+        , writers(1)
+    {}
+};
+
+pipe_t* create_pipe();
+int write_pipe(pipe_t* pipe, const void* data, size_t size);
+int read_pipe(pipe_t* pipe, void* buffer, size_t size);
+void close_pipe(pipe_t* pipe, bool is_write_end);


### PR DESCRIPTION
Implementation of Pipes and Messaging as referenced in the Roadmap. Permits for byte-streaming and message passing. Tested both of these on boot via Applications/piper.cpp

4096-byte ring buffer for Pipes alongside read and write tracking. Validates end of files and also cleans up once complete.
Message passing is 64-slot ring buffer with senderID, type and payload. Same blocking and stuff are pipes. Messages in whole rather than bytes.
Piper does a simple test that runs on boot to ensure passing.

Issues: Global Mutex vs a multi-process mutex means that only one app can use it at a time currently. Also all operations are blocking. Maybe in future make a variant that doesn't block?